### PR TITLE
Test for photon vendorid in findcores for win10 no driver -- fix #10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 changelog
 =========
+05/22/2015 - 1.5.11 - Test for photon vendorid in findcores for Windows 10 no driver
+
 05/21/2015 - 1.5.10 - Fix tiny but important typo in prompts around manual Wi-Fi credentials.
 
 05/21/2015 - 1.5.9 - Added manual Wi-Fi credential mode. If your Wi-Fi network is non-broadcast, or if you'd just rather avoid scanning for networks, you can choose to manually enter your network details.

--- a/commands/SerialCommand.js
+++ b/commands/SerialCommand.js
@@ -75,21 +75,31 @@ SerialCommand.prototype = extend(BaseCommand.prototype, {
 
 			//grab anything that self-reports as a core
 			ports.forEach(function (port) {
+				var deviceType;
+				
 				//not trying to be secure here, just trying to be helpful.
-				if ((port.manufacturer && port.manufacturer.indexOf('Spark') >= 0) ||
-					(port.pnpId && port.pnpId.indexOf('Spark_Core') >= 0) ||
-					(port.pnpId && port.pnpId.indexOf('VID_1D50') >= 0)) {
-
-					var device = { port: port.comName, type: 'Spark Core' };
-
-					if (port.vendorId === '0x2b04' && port.productId === '0xc006') {
-						device.type = 'Photon';
-					} else if (port.vendorId === '0x1d50' && port.productId === '0x607d') {
-						device.type = 'Core';
-					}
-
-					devices.push(device);
+				if ((port.pnpId && port.pnpId.indexOf('VID_2B04') >= 0 && 
+					port.pnpId && port.pnpId.indexOf('PID_C006') >= 0) || 
+					(port.vendorId === '0x2b04' && port.productId === '0xc006')) {
+						deviceType = 'Photon';
 				}
+				else if ((port.pnpId && port.pnpId.indexOf('VID_1D50') >= 0  && 
+					port.pnpId && port.pnpId.indexOf('PID_607D') >= 0) || 
+					(port.vendorId === '0x1d50' && port.productId === '0x607d')) {
+						deviceType = 'Core';
+				}
+				else if ((port.manufacturer && port.manufacturer.indexOf('Spark') >= 0) || 
+					(port.pnpId && port.pnpId.indexOf('Spark_Core') >= 0)) {
+					deviceType == 'Spark Core';
+				}
+				
+				console.log('deviceType: ' + deviceType);
+				console.log('port' + port.comName);
+
+				if (deviceType) {
+					var device = { port: port.comName, type: deviceType };
+					devices.push(device);	
+				}	
 			});
 
 			//if I didn't find anything, grab any 'ttyACM's

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "particle-cli",
   "description": "Simple Node commandline application for working with your Particle devices and using the Particle Cloud",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "author": "David Middlecamp",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fix for  #10

Here is an idea for testing for different device types while allowing for the no-driver scenario on windows 10 which doesn't have all of the device properties.

perhaps this could be better serviced by a getDeviceType helper? w00t and happy birthday dave! :) :+1: 

