### PR TITLE
Webhook fixes

### DIFF
--- a/commands/WebhookCommands.js
+++ b/commands/WebhookCommands.js
@@ -54,15 +54,19 @@ util.inherits(WebhookCommand, BaseCommand);
 WebhookCommand.HookJsonTemplate = {
     "event": "my-event",
     "url": "https://my-website.com/fancy_things.php",
-    "deviceID": "optionally filter by providing a device id",
+    "deviceid": "optionally filter by providing a device id",
 
     "_": "The following parameters are optional",
-    "requestType": "POST",
+    "mydevices": true/false
+    "requestType": ( "GET", "POST", "PUT", "DELETE" ),
+    "form": null;
     "headers": null,
     "query": null,
     "json": null,
     "auth": null,
-    "mydevices": true
+    "responseTemplate": null,
+    "rejectUnauthorized:" true/false,
+
 };
 
 WebhookCommand.prototype = extend(BaseCommand.prototype, {
@@ -133,7 +137,7 @@ WebhookCommand.prototype = extend(BaseCommand.prototype, {
                 //only override these when we didn't get them from the command line
                 eventName = data.event;
                 url = data.url;
-                deviceID = data.deviceID;
+                deviceID = data.deviceid;
             }
         }
 
@@ -153,7 +157,7 @@ WebhookCommand.prototype = extend(BaseCommand.prototype, {
 		//TODO: clean this up more?
 		data.event = eventName;
 		data.url = url;
-		data.deviceID = deviceID;
+		data.deviceid = deviceID;
 		data.access_token = api._access_token;
 		data.requestType = requestType || data.requestType;
 
@@ -190,7 +194,7 @@ WebhookCommand.prototype = extend(BaseCommand.prototype, {
                     var hook = hooks[i];
                     var line = [
                         "    ", (i+1),
-                        ".) Hook #" + hook.id + " is watching for ",
+                        ".) Hook " + hook.id + " is watching for ",
                         "\""+hook.event+"\"",
 
                         "\n       ", " and posting to: " + hook.url,

--- a/commands/WebhookCommands.js
+++ b/commands/WebhookCommands.js
@@ -57,25 +57,21 @@ WebhookCommand.HookJsonTemplate = {
     "deviceid": "optionally filter by providing a device id",
 
     "_": "The following parameters are optional",
-    "mydevices": true/false
-    "requestType": ( "GET", "POST", "PUT", "DELETE" ),
-    "form": null;
+    "mydevices": "true/false",
+    "requestType": "GET/POST/PUT/DELETE",
+    "form": null,
     "headers": null,
     "query": null,
     "json": null,
     "auth": null,
     "responseTemplate": null,
-    "rejectUnauthorized:" true/false,
-
+    "rejectUnauthorized": "true/false"
 };
 
 WebhookCommand.prototype = extend(BaseCommand.prototype, {
     options: null,
     name: "webhook",
     description: "Experimental Beta - helpers for reacting to device event streams",
-
-
-
     usagesByName: {
         "create": [
             "particle webhook create hook.json",
@@ -128,10 +124,15 @@ WebhookCommand.prototype = extend(BaseCommand.prototype, {
             var filename = eventName;
 
             if(utilities.getFilenameExt(filename) == ".json"){
-                console.log("here");
                 if (fs.existsSync(filename)) {
                     data = utilities.tryParse(fs.readFileSync(filename)) || {};
-                    console.log("Using settings from the file " + filename);
+                    if(typeof data == "object" && Object.keys(data).length == 0) {
+                      console.log("Please check your .json file");
+                      return -1;
+                    }
+                    else{
+                      console.log("Using settings from the file " + filename);
+                    }
                 }
 
                 //only override these when we didn't get them from the command line
@@ -148,11 +149,6 @@ WebhookCommand.prototype = extend(BaseCommand.prototype, {
             return -1;
         }
 
-        //required param
-        if (!deviceID || (deviceID == "")) {
-            console.log("Please specify a deviceID");
-            return -1;
-        }
 
 		//TODO: clean this up more?
 		data.event = eventName;

--- a/commands/WebhookCommands.js
+++ b/commands/WebhookCommands.js
@@ -194,7 +194,7 @@ WebhookCommand.prototype = extend(BaseCommand.prototype, {
                     var hook = hooks[i];
                     var line = [
                         "    ", (i+1),
-                        ".) Hook " + hook.id + " is watching for ",
+                        ".) Hook ID " + hook.id + " is watching for ",
                         "\""+hook.event+"\"",
 
                         "\n       ", " and posting to: " + hook.url,

--- a/lib/ApiClient.js
+++ b/lib/ApiClient.js
@@ -696,7 +696,7 @@ ApiClient.prototype = {
 		request(obj, function (error, response, body) {
 			that.hasBadToken(error, body);
 			if (body && body.ok) {
-				console.log("Successfully created webhook!");
+				console.log("Successfully created webhook with id: " + body.id);
 				dfd.resolve(body);
 			}
 			else if (body && body.error) {

--- a/serialPort.md
+++ b/serialPort.md
@@ -1,0 +1,47 @@
+Photon on Mac:
+
+```
+{ comName: '/dev/cu.usbmodem1411',
+  manufacturer: 'Spark Devices',
+  serialNumber: '00000000050C',
+  pnpId: '',
+  locationId: '0x14100000',
+  vendorId: '0x2b04',
+  productId: '0xc006' }
+```
+
+Spark core on Mac:
+
+```
+{ comName: '/dev/cu.usbmodem1411',
+  manufacturer: 'Spark Devices     ',
+  serialNumber: '8D6A41694854',
+  pnpId: '',
+  locationId: '0x14100000',
+  vendorId: '0x1d50',
+  productId: '0x607d' }
+```
+
+Photon on Windows:
+
+```
+{ comName: 'COM9',
+  manufacturer: 'Photon',
+  serialNumber: '',
+  pnpId: 'USB\\VID_2B04&PID_C006\\00000000050C',
+  locationId: '',
+  vendorId: '',
+  productId: '' }
+```
+
+Spark Core on Windows XP:
+
+```
+{ comName: 'COM10',
+  manufacturer: 'Spark Core',
+  serialNumber: '',
+  pnpId: 'USB\\VID_1D50&PID_607D\\8D6A41694854',
+  locationId: '',
+  vendorId: '',
+  productId: '' } 
+```

--- a/template.json
+++ b/template.json
@@ -1,0 +1,25 @@
+{
+  event: "",
+  url: "",
+  deviceid: "",
+  mydevices: ( true/false),
+  requestType: ( "GET", "POST", "PUT", "DELETE" ),
+  headers: {
+    "Authorization": ""
+  },
+  json: {},
+  query: {},
+  form: {
+    "custom-field": ""
+  },
+  auth: {
+    user: "",
+    pass: ""
+  },
+  responseTemplate: "",
+  rejectUnauthorized: true/false,
+  azure_sas_token:
+    { key_name: "",
+      key: ""
+    }
+}

--- a/test.json
+++ b/test.json
@@ -1,0 +1,14 @@
+{
+    "event": "hit-rqb",
+    url": "",
+    "deviceid": "",
+    "requestType": "POST",
+    "headers": null,
+    "query": null,
+    "json": {
+      "param_1": "1",
+      "param_2": "2"
+    },
+    "auth": null,
+    "mydevices": false
+}


### PR DESCRIPTION
- updated to `deviceID`
- print out `Hook ID` upon successful creation
- removed redundant `if (eventName && !url && !coreID)` as it is never
executed due to the `if statement` above
- check that file extension is a `.json` before parsing
- add prompt for empty `deviceID` since that’s a require param

Output:

- `particle webhook create my_event my_url my_id`

```bash
Successfully created webhook with id: 55752ff469928dd61748b0a0
```