### PR TITLE
Print-out account username

### DIFF
--- a/commands/AccessTokenCommands.js
+++ b/commands/AccessTokenCommands.js
@@ -65,7 +65,11 @@ AccessTokenCommands.prototype = extend(BaseCommand.prototype, {
 			var creds = when.defer();
 
 			inquirer.prompt([
-				prompts.getPassword('Please re-enter your password')
+				{
+					type: 'password',
+					name: 'password',
+					message: "Using account "+  settings.username + '\nPlease enter your password:'
+				}
 			], function (answers) {
 				creds.resolve({
 					username: settings.username,


### PR DESCRIPTION
- This should reduce @_@ by showing which account the user is currently on.
- Mention `enter password` instead of `re-enter` since they are not re-entering



Fixes: https://github.com/spark/spark-cli/pull/177