### PR TITLE
add `.der` to saved keys file

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ Saved!
 Copies a ```.DER``` formatted private key from your device's external flash to your computer.  Make sure your device is connected and in [dfu mode](http://docs.particle.io/core/modes/#core-modes-dfu-mode-device-firmware-upgrade).  The ```particle keys``` tools requires both dfu-util, and openssl to be installed.
 
 ```sh
-$ particle keys save device.der
+$ particle keys save name_of_file
 ...
 Saved!
 ```


### PR DESCRIPTION
- core —> device
- require user to only specify a filename as mentioned in `console.log()`

From: https://github.com/spark/spark-cli/pull/176