### PR TITLE
resolve error if renaming fails

### DIFF
--- a/lib/ApiClient.js
+++ b/lib/ApiClient.js
@@ -340,11 +340,9 @@ ApiClient.prototype = {
 			that.hasBadToken(error, body);
 
 			if (body && (body.name === name)) {
-				console.log("Successfully renamed device " + coreID + " to: " + name);
 				dfd.resolve(body);
 			}
 			else {
-				console.log("Failed to rename device, server said ", body.errors || body);
 				dfd.reject(body);
 			}
 		});


### PR DESCRIPTION
- core —> device
- console output is now removed from `ApiClient.js`

Old output:

```sh
Failed to rename device, server said  [ 'Name already in use' ]
Potentially unhandled rejection [1] {"ok":false,"errors":["Name already
in use"]} (WARNING: non-Error used)
```

Now:

```sh
Failed to rename photon-1, server said [ 'Name already in use' ]
```