### PR TITLE
Webhook fixes

### DIFF
--- a/commands/WebhookCommands.js
+++ b/commands/WebhookCommands.js
@@ -164,6 +164,7 @@ WebhookCommand.prototype = extend(BaseCommand.prototype, {
 		data.deviceid = deviceID;
 		data.access_token = api._access_token;
 		data.requestType = requestType || data.requestType;
+    if (data.mydevices == undefined) data.mydevices = true;
 
 		api.createWebhookWithObj(data);
 

--- a/lib/ApiClient.js
+++ b/lib/ApiClient.js
@@ -694,7 +694,7 @@ ApiClient.prototype = {
 		request(obj, function (error, response, body) {
 			that.hasBadToken(error, body);
 			if (body && body.ok) {
-				console.log("Successfully created webhook!");
+				console.log("Successfully created webhook with ID " +  body.id);
 				dfd.resolve(body);
 			}
 			else if (body && body.error) {


### PR DESCRIPTION
- update `.json` template
- coreID —> deviceid
- check that `.json` file is found
- check that `.json` file can be parsed or fail
- `particle webhook GET` works now
- `particle webhook POST` works now
- `particle webhook create xxx.json` has also been tested
- print out `hookID` upon hook creation