### PR TITLE
fixed resolve error

### DIFF
--- a/lib/dfu.js
+++ b/lib/dfu.js
@@ -50,8 +50,10 @@ var that = module.exports = {
 					return temp.resolve();
 				}
 			});
-			console.log("Apparently I didn't find a DFU device? util said ", stdout);
-			temp.reject("no dfu device found.");
+			if (that.deviceID == undefined){
+				console.log("Apparently I didn't find a DFU device? util said ", stdout);
+				temp.reject("no dfu device found.");
+			}
 		});
 
 		return temp.promise;


### PR DESCRIPTION
Based on https://github.com/spark/particle-cli/commit/31299a53098c6336be1e35e1db77367e4b1f8361,
the change from `for loop()` to `forEach` does not bail out on the `return` and ends up executing code below.

Without this fix, there's always a `Apparently I didn't find a DFU device? util said  dfu-util 0.8` statement

Signed-off-by: Kenneth Lim <kennethlimcp@gmail.com>