### PR TITLE
Compile for specific device

### DIFF
--- a/commands/CloudCommands.js
+++ b/commands/CloudCommands.js
@@ -259,10 +259,36 @@ CloudCommand.prototype = extend(BaseCommand.prototype, {
 
 	},
 
-	compileCode: function () {
-		//  "Please specify a binary file, source file, or source directory");
+	compileCode: function (deviceType) {
+		if (!deviceType) {
+			console.error("\nPlease specify the target device type. eg. particle compile photon xxx\n");
+			return;
+		}
 
-		var args = Array.prototype.slice.call(arguments, 0);
+		//defaults to 0 for core
+		var platform_id = 0;
+
+		switch (deviceType) {
+		  case "photon":
+		  case "p":
+				deviceType = "photon";
+				platform_id = 6;
+		    break;
+
+		  case "core":
+			case "c":
+				deviceType = "core";
+				break;
+
+		  default:
+		    console.error("\nTarget device " + deviceType + " is not valid\n");
+		    return;
+		}
+
+		console.log("\nCompiling code for " + deviceType + "\n");
+
+		//  "Please specify a binary file, source file, or source directory");
+		var args = Array.prototype.slice.call(arguments, 1);
 		if (args.length == 0) {
 			args.push("."); //default to current directory
 		}
@@ -301,7 +327,7 @@ CloudCommand.prototype = extend(BaseCommand.prototype, {
 			//this should have no side-effects with other usages.  If we did a more sophisticated
 			//argument structure, we'd need to change this logic.
 			if (!filename || (utilities.getFilenameExt(filename) != ".bin")) {
-				filename = "firmware_" + (new Date()).getTime() + ".bin";
+				filename = deviceType + "_firmware_" + (new Date()).getTime() + ".bin";
 			}
 		}
 
@@ -315,7 +341,7 @@ CloudCommand.prototype = extend(BaseCommand.prototype, {
 		var allDone = pipeline([
 			//compile
 			function () {
-				return api.compileCode(files);
+				return api.compileCode(files, platform_id);
 			},
 
 			//download

--- a/lib/ApiClient.js
+++ b/lib/ApiClient.js
@@ -448,7 +448,7 @@ ApiClient.prototype = {
 		return dfd.promise;
 	},
 
-	compileCode: function(files) {
+	compileCode: function(files, platform_id) {
 	   console.log('attempting to compile firmware ');
 
 		var that = this;
@@ -476,6 +476,7 @@ ApiClient.prototype = {
 			//form.append("branch", "compile-server2");
 			//form.append("latest", "true");
 		}
+		form.append("platform_id", platform_id);
 
 		return dfd.promise;
 	},


### PR DESCRIPTION
- take in extra param for `deviceType`
- Fixes: https://github.com/spark/particle-cli/issues/15
- Fixes: https://github.com/spark/particle-cli/issues/16

**Docs:**

To compile code using the Cloud build farm, you need to specify the target device. 

- eg. Target a Photon
    - `particle compile photon xxxx`
    - `particle compile p xxxx` <---- short-form to reduce typing per compile

- eg. Target a Core
    - `particle compile core xxxx`
    - `particle compile c xxxx` <---- short-form to reduce typing per compile

- eg. No device specified 
    - `particle compile`

    Error:  `Please specify the target device type. eg. particle compile photon xxx`

The current PR insists on a deviceType to be passed but we can also make it optional and default to `core` if that's better.


Signed-off-by: Kenneth Lim <kennethlimcp@gmail.com>