### PR TITLE
Added "remove" verb for webhook

### DIFF
--- a/commands/WebhookCommands.js
+++ b/commands/WebhookCommands.js
@@ -92,7 +92,7 @@ WebhookCommand.prototype = extend(BaseCommand.prototype, {
         this.addOption("create", this.createHook.bind(this), "Creates a postback to the given url when your event is sent");
         this.addOption("list", this.listHooks.bind(this), "Show your current Webhooks");
         this.addOption("delete", this.deleteHook.bind(this), "Deletes a Webhook");
-
+        this.addOption("remove", this.deleteHook.bind(this), "Deletes a Webhook");
 	    this.addOption("POST", this.createPOSTHook.bind(this), "Create a new POST request hook");
         this.addOption("GET", this.createGETHook.bind(this), "Create a new GET request hook");
     },


### PR DESCRIPTION
Fixes: https://github.com/spark/particle-cli/issues/23

Signed-off-by: Kenneth Lim <kennethlimcp@gmail.com>