### PR TITLE
Format compile errors when doing `particle flash`

### DIFF
--- a/lib/ApiClient.js
+++ b/lib/ApiClient.js
@@ -433,7 +433,14 @@ ApiClient.prototype = {
 				dfd.reject(error);
 			}
 			else {
-				console.log("flash device said ", JSON.stringify(body || error));
+                if(body.errors) {
+                    console.log("Compile failed");
+                    console.log(body.errors.map(function(e) {
+                      return e.errors.join("\n")
+                    }).join("\n"));
+                } else {
+				    console.log("flash device said ", JSON.stringify(body));
+                }
 				dfd.resolve(response);
 			}
 		});


### PR DESCRIPTION
The `particle compile` command formats compiler errors in a readable format. When using `particle flash`, the compiler errors are returned in a stringified JSON hash which is hard to read.

This PR adds formats the error output of `particle flash` in a similar fashion to the error output of `particle compile`

I'm actually surprised at the difference in the JSON format returned by those 2 cloud API commands.

**JSON response to compile cloud API command**

```
{
  "ok": false,
  "output": "Compiler timed out or encountered an error",
  "stdout": "Building core-common-lib\nmake[1]: ...",
  "errors": [
    "build didn't produce binary Error: Command failed: In file included from ..\/inc\/spark_wiring.h:29:0...",
    "In file included from ..\/inc\/spark_wiring.h:29:0,...",
    {
      "killed": false,
      "code": 2,
      "signal": null
    }
  ]
}
```


**JSON response to flash cloud API command**

```
{
  "ok": false,
  "errors": [
    {
      "ok": false,
      "output": "Compiler timed out or encountered an error",
      "stdout": "Building core-common-lib\nmake[1]: ...",
      "errors": [
        "build didn't produce binary Error: Command failed: ...",
        "In file included from ..\/inc\/spark_wiring.h:29:0, ...",
        {
          "killed": false,
          "code": 2,
          "signal": null
        }
      ]
    }
  ]
}
```

Why this difference? Can there be more than 1 array element in the top-level errors key of the flash API command?