### PR TITLE
Allow passing --deviceType to 'particle compile'

### DIFF
--- a/commands/CloudCommands.js
+++ b/commands/CloudCommands.js
@@ -102,6 +102,13 @@ CloudCommand.prototype = extend(BaseCommand.prototype, {
 				console.log("Please specify a file path when using --saveTo");
 			}
 		}
+
+		if (utilities.contains(args, "--deviceType")) {
+			var idx = utilities.indexOf(args, "--deviceType");
+			if ((idx + 1) < args.length) {
+				this.options.deviceType = args[idx + 1];
+			}
+		}
 	},
 
 	claimDevice: function (deviceid) {
@@ -305,6 +312,16 @@ CloudCommand.prototype = extend(BaseCommand.prototype, {
 			}
 		}
 
+		var productId;
+		switch(this.options.deviceType) {
+			case "photon":
+				productId = 6;
+				break;
+			default:
+			case "core":
+				productId = 0;
+				break;
+		}
 
 		var that = this;
 		var api = new ApiClient(settings.apiUrl, settings.access_token);
@@ -315,7 +332,7 @@ CloudCommand.prototype = extend(BaseCommand.prototype, {
 		var allDone = pipeline([
 			//compile
 			function () {
-				return api.compileCode(files);
+				return api.compileCode(files, productId);
 			},
 
 			//download

--- a/lib/ApiClient.js
+++ b/lib/ApiClient.js
@@ -448,7 +448,7 @@ ApiClient.prototype = {
 		return dfd.promise;
 	},
 
-	compileCode: function(files) {
+	compileCode: function(files, productId) {
 	   console.log('attempting to compile firmware ');
 
 		var that = this;
@@ -476,6 +476,8 @@ ApiClient.prototype = {
 			//form.append("branch", "compile-server2");
 			//form.append("latest", "true");
 		}
+
+		form.append("product_id", productId);
 
 		return dfd.promise;
 	},


### PR DESCRIPTION
Right now it is not possible to compile binaries for the Photon using `particle-cli`, this PR allows the passing of an optional `--deviceType` to `particle complile` (which defaults to "core") which allows you to specify the compilation target.