### PR TITLE
add compile syntax examples upon invalid input

### DIFF
--- a/commands/CloudCommands.js
+++ b/commands/CloudCommands.js
@@ -281,7 +281,9 @@ CloudCommand.prototype = extend(BaseCommand.prototype, {
 				break;
 
 		  default:
-		    console.error("\nTarget device " + deviceType + " is not valid\n");
+		    console.error("\nTarget device " + deviceType + " is not valid");
+				console.error("	eg. particle compile core xxx");
+				console.error("	eg. particle compile photon xxx\n");
 		    return;
 		}
 


### PR DESCRIPTION
This will reduce friction from the updated compile command. Fixes: https://github.com/spark/particle-cli/issues/58

Signed-off-by: Kenneth Lim <kennethlimcp@gmail.com>