### PR TITLE
validate SSID prompt

### DIFF
--- a/commands/SerialCommand.js
+++ b/commands/SerialCommand.js
@@ -315,6 +315,12 @@ SerialCommand.prototype = extend(BaseCommand.prototype, {
 				type: 'input',
 				name: 'ssid',
 				message: 'SSID',
+				validate: function(input) {
+					if(input.length == 0)
+						return "please enter a valid SSID";
+					else
+						return true;
+				},
 				when: function (answers) { return !networks.length || !answers.ap; }
 			},
 			{


### PR DESCRIPTION
This will check that the non-empty SSID is entered before prompting further.

Fixes: https://github.com/spark/particle-cli/issues/62

Error message is: `>> please enter a valid SSID`

Signed-off-by: Kenneth Lim <kennethlimcp@gmail.com>