### PR TITLE
Fix for Incomplete use of 'sudo' when running 'dfu-util'

### DIFF
--- a/lib/dfu.js
+++ b/lib/dfu.js
@@ -41,7 +41,8 @@ var that = module.exports = {
 		var temp = when.defer();
 
 		var failTimer = utilities.timeoutGenerator("findCompatibleDFU timed out", temp, 6000);
-		child_process.exec("dfu-util -l", function (error, stdout, stderr) {
+		var cmd = that.getCommand() + " -l";
+		child_process.exec(cmd, function (error, stdout, stderr) {
 			clearTimeout(failTimer);
 			Object.keys(specs).forEach(function (id) {
 				if(stdout.indexOf(id) >= 0) {
@@ -84,13 +85,13 @@ var that = module.exports = {
 	},
 
 	isDfuUtilInstalled: function() {
-		var cmd = "dfu-util -l";
+		var cmd = that.getCommand() + " -l";
 		var installCheck = utilities.deferredChildProcess(cmd);
 		return utilities.replaceDfdResults(installCheck, "Installed", "dfu-util is not installed");
 	},
 
 	readDfu: function (memoryInterface, destination, firmwareAddress, leave) {
-		var prefix = that.getCommandPrefix();
+		var prefix = that.getCommand() + " -d " + that.deviceID;
 		var leaveStr = (leave) ? ":leave" : "";
 		var cmd = prefix + ' -a ' + memoryInterface + ' -s ' + firmwareAddress + leaveStr + ' -U ' + destination;
 
@@ -108,12 +109,16 @@ var that = module.exports = {
 		];
 
 		that.checkBinaryAlignment("-D " + binaryPath);
-		return utilities.deferredSpawnProcess("dfu-util", args);
+		return utilities.deferredChildProcess(that.getCommand() + ' ' + args.join(' '));
 	},
 
-	getCommandPrefix: function () {
-		var sudo = (settings.useSudoForDfu) ? "sudo " : "";
-		return sudo + "dfu-util -d " + that.deviceID;
+	getCommand: function () {
+		if (settings.useSudoForDfu) {
+			return "sudo dfu-util";
+		}
+		else {
+			return "dfu-util";
+		}
 	},
 
 	checkBinaryAlignment: function (cmdargs) {


### PR DESCRIPTION
Use sudo when `useSudoForDfu` option is `true` for every dfu command.

Should fix issue #51