### PR TITLE
Properly format the compilation output of the flash command

### DIFF
--- a/commands/CloudCommands.js
+++ b/commands/CloudCommands.js
@@ -226,7 +226,14 @@ CloudCommand.prototype = extend(BaseCommand.prototype, {
 			return -1;
 		}
 
-		return api.flashDevice(deviceid, files);
+		api.flashDevice(deviceid, files).then(function(resp) {
+			if(resp.message) {
+				console.log("Flash device OK: ", resp.message);
+			} else if(resp.errors) {
+				console.log("Flash device failed");
+				console.log(resp.errors.join("\n"));
+			}
+		});
 	},
 
 	/**

--- a/commands/FlashCommand.js
+++ b/commands/FlashCommand.js
@@ -125,7 +125,7 @@ FlashCommand.prototype = extend(BaseCommand.prototype, {
 
 	flashCloud: function(coreid, filename) {
 		var cloud = this.cli.getCommandModule("cloud");
-		return cloud.flashDevice.apply(cloud, arguments);
+		cloud.flashDevice.apply(cloud, arguments);
 	},
 
 	flashDfu: function(firmware) {

--- a/lib/ApiClient.js
+++ b/lib/ApiClient.js
@@ -433,8 +433,7 @@ ApiClient.prototype = {
 				dfd.reject(error);
 			}
 			else {
-				console.log("flash device said ", JSON.stringify(body || error));
-				dfd.resolve(response);
+				dfd.resolve(body);
 			}
 		});
 


### PR DESCRIPTION
Fix #66 by properly formatting the output of the `particle flash` command when the compilation fails.

Note: I signed the CLA.