### PR TITLE
Prompt to install UDEV rules for dfu

### DIFF
--- a/lib/50-particle.rules
+++ b/lib/50-particle.rules
@@ -1,0 +1,39 @@
+# UDEV Rules for Particle boards
+#
+# This will allow reflashing with DFU-util without using sudo
+#
+# The latest version of this file may be found at:
+#   https://gist.github.com/monkbroc/b283bb4da8c10228a61e
+#
+# This file must be placed at:
+#
+# /etc/udev/rules.d/50-particle.rules    (preferred location)
+#
+# To install, type this command in a terminal:
+#   sudo cp 50-particle.rules /etc/udev/rules.d/50-particle.rules
+#
+# After this file is installed, physically unplug and reconnect the
+# Particle device.
+#
+# Core
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="607[df]", GROUP="plugdev", MODE="0666"
+# Photon/P1/Electron
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2b04", ATTRS{idProduct}=="[cd]00?", GROUP="plugdev", MODE="0666"
+#
+# If you share your linux system with other users, or just don't like the
+# idea of write permission for everybody, you can replace MODE:="0666" with
+# OWNER:="yourusername" to create the device owned by you, or with
+# GROUP:="somegroupname" and mange access using standard unix groups.
+#
+#
+# If using USB Serial you get a new device each time (Ubuntu >9.10)
+# eg: /dev/ttyACM0, ttyACM1, ttyACM2, ttyACM3, ttyACM4, etc
+#    apt-get remove --purge modemmanager     (reboot may be necessary)
+#
+# CREDITS:
+#
+# Edited by Julien Vanier
+#
+# This file is derived from the Teensy UDEV rules
+# http://www.pjrc.com/teensy/49-teensy.rules
+#

--- a/lib/dfu.js
+++ b/lib/dfu.js
@@ -23,7 +23,7 @@ Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public
 License along with this program; if not, see <http://www.gnu.org/licenses/>.
  ******************************************************************************
- */
+*/
 
 var fs = require('fs');
 var when = require('when');
@@ -45,7 +45,6 @@ var that = module.exports = {
 	deviceID: undefined,
 	findCompatibleDFU: function () {
 		var temp = when.defer();
-		var that = this;
 
 		var failTimer = utilities.timeoutGenerator('findCompatibleDFU timed out', temp, 6000);
 		var cmd = that.getCommand() + ' -l';
@@ -53,7 +52,12 @@ var that = module.exports = {
 			clearTimeout(failTimer);
 			if (error || stderr) {
 				console.error(error || stderr);
-				return temp.reject(error || stderr);
+
+				if(that._missingDevicePermissions(stderr) && that._systemSupportsUdev()) {
+					return that._promptInstallUdevRules().then(temp.reject, temp.reject);
+				} else {
+					return temp.reject(error || stderr);
+				}
 			}
 
 			// find DFU devices that match specs
@@ -293,6 +297,55 @@ var that = module.exports = {
 			segment.specs.address,
 			leave
 		);
+	},
+
+	_udevRulesDir: '/etc/udev/rules.d/',
+
+	_missingDevicePermissions: function (stderr) {
+		return stderr && stderr.indexOf("Cannot open DFU device") >= 0;
+	},
+
+	_systemSupportsUdev: function() {
+		return fs.existsSync(that._udevRulesDir);
+	},
+
+	_promptInstallUdevRules: function() {
+		var temp = when.defer();
+		console.log(chalk.yellow('You are missing the permissions to use DFU without root.'));
+		prompt([{
+			type: 'confirm',
+			name: 'install',
+			message: 'Would you like to install a UDEV rules file to get access?',
+			default: true
+		}], function(ans) {
+			that._installUdevChoice(ans, temp);
+		});
+
+		return temp.promise;
+	},
+
+	_installUdevChoice: function(ans, promise) {
+		var message = 'Missing permissions to use DFU';
+		if (ans.install) {
+			var rules = __dirname + '/50-particle.rules';
+			var cmd = "sudo cp '" + rules + "' '" + that._udevRulesDir + "'";
+			console.log(cmd);
+			child_process.exec(cmd, function(error, stdout, stderr) {
+				if(error) {
+					console.error('Could not install UDEV rules');
+					promise.reject(message);
+				} else {
+					console.log('UDEV rules for DFU installed.');
+					console.log(chalk.bold.red(
+						'Physically unplug and reconnect the Particle device.\n' +
+						'Then run the particle command again.'
+					));
+					promise.resolve(message);
+				}
+			});
+		} else {
+			promise.reject(message);
+		}
 	},
 
 	_: null

--- a/lib/dfu.js
+++ b/lib/dfu.js
@@ -299,7 +299,12 @@ var that = module.exports = {
 		);
 	},
 
+	// UDEV rules on Linux allow regular user acess to devices that
+	// normally need superuser permissions. Install some UDEV rules for
+	// the Particle devices if necessary.
+
 	_udevRulesDir: '/etc/udev/rules.d/',
+	_udevRulesFile: '50-particle.rules',
 
 	_missingDevicePermissions: function (stderr) {
 		return stderr && stderr.indexOf("Cannot open DFU device") >= 0;
@@ -309,17 +314,28 @@ var that = module.exports = {
 		return fs.existsSync(that._udevRulesDir);
 	},
 
+	_udevRulesInstalled: function() {
+		return fs.existsSync(that._udevRulesDir + '/' + that._udevRulesFile);
+	},
+
 	_promptInstallUdevRules: function() {
 		var temp = when.defer();
-		console.log(chalk.yellow('You are missing the permissions to use DFU without root.'));
-		prompt([{
-			type: 'confirm',
-			name: 'install',
-			message: 'Would you like to install a UDEV rules file to get access?',
-			default: true
-		}], function(ans) {
-			that._installUdevChoice(ans, temp);
-		});
+		if(that._udevRulesInstalled()) {
+			console.log(chalk.bold.red(
+				'Physically unplug and reconnect the Particle device and try again.'
+			));
+			temp.reject('Missing permissions to use DFU');
+		} else {
+			console.log(chalk.yellow('You are missing the permissions to use DFU without root.'));
+			prompt([{
+				type: 'confirm',
+				name: 'install',
+				message: 'Would you like to install a UDEV rules file to get access?',
+				default: true
+			}], function(ans) {
+				that._installUdevChoice(ans, temp);
+			});
+		}
 
 		return temp.promise;
 	},
@@ -327,7 +343,7 @@ var that = module.exports = {
 	_installUdevChoice: function(ans, promise) {
 		var message = 'Missing permissions to use DFU';
 		if (ans.install) {
-			var rules = __dirname + '/50-particle.rules';
+			var rules = __dirname + '/' + that._udevRulesFile;
 			var cmd = "sudo cp '" + rules + "' '" + that._udevRulesDir + "'";
 			console.log(cmd);
 			child_process.exec(cmd, function(error, stdout, stderr) {


### PR DESCRIPTION
On Linux only root can access USB devices through dfu. Right now doing `particle flash --usb` will say "no dfu device found" without suggesting how to fix the issue.

It's possible to use sudo to work around this, but a better solution is to install UDEV rules to allow any user to access a particular device.

This PR prompts the user to install UDEV rules when the dfu-util failure indicates missing permissions.

The UDEV rules was checked for the Photon on Ubuntu 15.10. I included rules for the Core, P1 and Electron, but I can't try those.

Somebody working on the CLI should review the code and check if I put the code in the right place as I'm not familiar with the structure of the application.

This fixes #74.