### PR TITLE
Use spawn over child process

### DIFF
--- a/lib/dfu.js
+++ b/lib/dfu.js
@@ -111,7 +111,7 @@ var that = module.exports = {
 		];
 
 		that.checkBinaryAlignment("-D " + binaryPath);
-		return utilities.deferredChildProcess(that.getCommand() + ' ' + args.join(' '));
+		return utilities.deferredSpawnProcess(that.getCommand(),args);
 	},
 
 	getCommand: function () {


### PR DESCRIPTION
Reverting to the original way to call a process until there's sufficient reasons as to why a child process over a spawn is required.

This is related to https://github.com/spark/particle-cli/issues/80 where commit https://github.com/spark/particle-cli/pull/65 essentially removed dfu verbose which is not a deliberate decision.

Signed-off-by: Kenneth Lim <kennethlimcp@gmail.com>