### PR TITLE
Settings flag for default compile target

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,14 @@ $ particle flash --usb firmware.bin
 
   eg. `particle compile photon xxx` OR `particle compile p xxxx` both targets the photon
 
+  The default target device is **core**.
+
+  eg. `particle compile .` VS `particle compile core .`
+
+  **NOTE**: There is also a `defaultCompileDevice` flag that allows the user to target a device by default and omit the `device_type` argument.
+
+  To set the default target for your profile, use the command `particle config defaultCompileDevice device_type`.
+
   Note!  The cloud compiles ```.ino``` and ```.cpp``` files differently.  For ```.ino``` files, the cloud will apply a pre-processor.  It will add missing function declarations, and it will inject an ```#include "
   application.h"``` line at the top of your files if it is missing.
 

--- a/commands/CloudCommands.js
+++ b/commands/CloudCommands.js
@@ -298,7 +298,6 @@ CloudCommand.prototype = extend(BaseCommand.prototype, {
 	},
 
 	compileCode: function (deviceType) {
-
 		deviceType = 	deviceType.toLowerCase();
 		//defaults to 0 for core
 		var platform_id = 0;

--- a/commands/CloudCommands.js
+++ b/commands/CloudCommands.js
@@ -298,7 +298,7 @@ CloudCommand.prototype = extend(BaseCommand.prototype, {
 	},
 
 	compileCode: function (deviceType) {
-		deviceType = 	deviceType.toLowerCase();
+		deviceType = deviceType.toLowerCase();
 		//defaults to 0 for core
 		var platform_id = 0;
 
@@ -319,7 +319,7 @@ CloudCommand.prototype = extend(BaseCommand.prototype, {
 			default:
 				deviceType = settings.defaultCompileDevice;
 				console.log("\nCompiling code for default target: " + deviceType  + "\n");
-				}
+		}
 
 
 		//  "Please specify a binary file, source file, or source directory");

--- a/commands/CloudCommands.js
+++ b/commands/CloudCommands.js
@@ -298,34 +298,30 @@ CloudCommand.prototype = extend(BaseCommand.prototype, {
 	},
 
 	compileCode: function (deviceType) {
-		if (!deviceType) {
-			console.error("\nPlease specify the target device type. eg. particle compile photon xxx\n");
-			return;
-		}
 
+		deviceType = 	deviceType.toLowerCase();
 		//defaults to 0 for core
 		var platform_id = 0;
 
 		switch (deviceType) {
-		  case "photon":
-		  case "p":
+			case "photon":
+			case "p":
 				deviceType = "photon";
 				platform_id = 6;
-		    break;
-
-		  case "core":
-			case "c":
-				deviceType = "core";
+				console.log("\nCompiling code for " + deviceType + "\n");
 				break;
 
-		  default:
-		    console.error("\nTarget device " + deviceType + " is not valid");
-				console.error("	eg. particle compile core xxx");
-				console.error("	eg. particle compile photon xxx\n");
-		    return;
-		}
+			case "core":
+			case "c":
+				deviceType = "core";
+				console.log("\nCompiling code for " + deviceType + "\n");
+				break;
 
-		console.log("\nCompiling code for " + deviceType + "\n");
+			default:
+				deviceType = settings.defaultCompileDevice;
+				console.log("\nCompiling code for default target: " + deviceType  + "\n");
+				}
+
 
 		//  "Please specify a binary file, source file, or source directory");
 		var args = Array.prototype.slice.call(arguments, 1);
@@ -344,6 +340,7 @@ CloudCommand.prototype = extend(BaseCommand.prototype, {
 
 		//make a copy of the arguments
 		var files = this._handleMultiFileArgs(args);
+
 		if (!files) {
 
 			console.log("No source to compile!");

--- a/commands/ConfigCommand.js
+++ b/commands/ConfigCommand.js
@@ -24,7 +24,7 @@ You should have received a copy of the GNU Lesser General Public
 License along with this program; if not, see <http://www.gnu.org/licenses/>.
  ******************************************************************************
  */
- 
+
 var when = require('when');
 var sequence = require('when/sequence');
 var readline = require('readline');
@@ -107,11 +107,12 @@ ConfigCommand.prototype = extend(BaseCommand.prototype, {
 	changeSetting: function (group, name, value) {
 		settings.override(group, name, value);
 	},
-	
+
 	identifyServer: function () {
 		console.log("Current profile: " + settings.profile);
 		console.log("Using API: " + settings.apiUrl);
 		console.log("Access token: " +  settings.access_token);
+		console.log("Default compile target: " +  settings.defaultCompileDevice);
 	},
 
 	listConfigs: function() {

--- a/settings.js
+++ b/settings.js
@@ -41,6 +41,7 @@ var settings = {
 	minimumApiDelay: 500,
 	//useOpenSSL: true,
 	useSudoForDfu: false,
+	defaultCompileDevice: "core",
 
 	//2 megs -- this constant here is arbitrary
 	MAX_FILE_SIZE: 1024 * 1024 * 2,


### PR DESCRIPTION
- You type less
- More ready for non-interactive CLI
- improved `deviceType` argument parsing by making it lowercase

**NOTE**
- Need to add in docs in README before merging

Signed-off-by: Kenneth Lim <kennethlimcp@gmail.com>