### PR TITLE
Accept either event or eventName in the webhook JSON

### DIFF
--- a/commands/WebhookCommands.js
+++ b/commands/WebhookCommands.js
@@ -132,7 +132,7 @@ WebhookCommand.prototype = extend(BaseCommand.prototype, {
                     else{
                       console.log("Using settings from the file " + filename);
                       //only override these when we didn't get them from the command line
-                      eventName = data.event;
+                      eventName = data.event || data.eventName;
                       url = data.url;
                       deviceID = data.deviceid;
                     }


### PR DESCRIPTION
Both forms are shown in the documentation: [shows eventName](https://docs.particle.io/guide/tools-and-features/webhooks/#what-39-s-in-a-request-) and [shows event](https://docs.particle.io/guide/tools-and-features/webhooks/#templates)

[This trips users up](http://community.particle.io/t/cannot-create-very-simple-webhook-please-specify-event-name-error/14196) so just accept either :)