### PR TITLE
fixes native types being form-encoded which causes them to lose type info

### DIFF
--- a/commands/WebhookCommands.js
+++ b/commands/WebhookCommands.js
@@ -162,7 +162,6 @@ WebhookCommand.prototype = extend(BaseCommand.prototype, {
 		data.event = eventName;
 		data.url = url;
 		data.deviceid = deviceID;
-		//data.access_token = api._access_token;
 		data.requestType = requestType || data.requestType;
         if (data.mydevices == undefined) {
             data.mydevices = true;

--- a/commands/WebhookCommands.js
+++ b/commands/WebhookCommands.js
@@ -162,7 +162,7 @@ WebhookCommand.prototype = extend(BaseCommand.prototype, {
 		data.event = eventName;
 		data.url = url;
 		data.deviceid = deviceID;
-		data.access_token = api._access_token;
+		//data.access_token = api._access_token;
 		data.requestType = requestType || data.requestType;
         if (data.mydevices == undefined) {
             data.mydevices = true;

--- a/lib/ApiClient.js
+++ b/lib/ApiClient.js
@@ -688,8 +688,10 @@ ApiClient.prototype = {
 		var obj = {
 			uri: this.baseUrl + "/v1/webhooks",
 			method: "POST",
-			json: true,
-			form: obj
+			json: obj,
+			headers: {
+				"Authorization": "Bearer " + this._access_token
+			}
 		};
 
 		console.log("Sending webhook request ", obj);


### PR DESCRIPTION
uses a bearer token and a JSON request so we don't form-encode /  'stringify' native types in the request body.  Fixes https://community.particle.io/t/webhook-adding-double-quotes-to-boolean-value/15199/2