### PR TITLE
Compile/Flash build targeting

### DIFF
--- a/lib/ApiClient.js
+++ b/lib/ApiClient.js
@@ -467,7 +467,7 @@ ApiClient.prototype = {
 		return dfd.promise;
 	},
 
-	compileCode: function(files, platform_id) {
+	compileCode: function(files, platform_id, targetVersion) {
 		console.log('attempting to compile firmware ');
 
 		var that = this;
@@ -495,6 +495,11 @@ ApiClient.prototype = {
 			//form.append("latest", "true");
 		}
 		form.append('platform_id', platform_id);
+		if (targetVersion) {
+			form.append('build_target_version', targetVersion);
+		} else {
+			form.append('latest', 'true');
+		}
 
 		return dfd.promise;
 	},
@@ -829,7 +834,29 @@ ApiClient.prototype = {
 		return dfd.promise;
 	},
 
+	getBuildTargets: function() {
+		var that = this;
+		var dfd = when.defer();
+		request({
+			uri: this.baseUrl + '/v1/build_targets',
+			qs: {
+				access_token: this._access_token,
+				featured: true
+			},
+			method: 'GET',
+			json: true
+		}, function (error, response, body) {
+			if (error) {
+				return dfd.reject(error);
+			}
+			if (that.hasBadToken(body)) {
+				return dfd.reject('Invalid token');
+			}
+			dfd.resolve(body);
+		});
 
+		return dfd.promise;
+	},
 
 	hasBadToken: function(body) {
 		if (body && body.error && body.error.indexOf

--- a/lib/ApiClient.js
+++ b/lib/ApiClient.js
@@ -439,7 +439,7 @@ ApiClient.prototype = {
 	},
 
 	//PUT /v1/devices/{DEVICE_ID}
-	flashDevice: function (deviceId, files) {
+	flashDevice: function (deviceId, files, targetVersion) {
 		console.log('attempting to flash firmware to your device ' + deviceId);
 
 		var that = this;
@@ -462,6 +462,11 @@ ApiClient.prototype = {
 			form.append(name, fs.createReadStream(files[name]), {
 				filename: files[name]
 			});
+		}
+		if (targetVersion) {
+			form.append('build_target_version', targetVersion);
+		} else {
+			form.append('latest', 'true');
 		}
 
 		return dfd.promise;


### PR DESCRIPTION
Fixes #183

Adds `--target` argument to compile and flash commands to specify a build target. Defaults to `latest`.

The compile command is a little friendlier because it will report all valid build targets if given an invalid one. The flash command cannot currently do this because we don’t know the exact platform of the device (yet).