### PR TITLE
Use serialNumber to identify serial devices on Linux

### DIFF
--- a/commands/SerialCommand.js
+++ b/commands/SerialCommand.js
@@ -95,11 +95,13 @@ SerialCommand.prototype = extend(BaseCommand.prototype, {
 					}
 					var vid = deviceSpec.serial.vid;
 					var pid = deviceSpec.serial.pid;
+					var serialNumber = deviceSpec.serial.serialNumber;
 
 					var usbMatches = (port.vendorId === '0x' + vid.toLowerCase() && port.productId === '0x' + pid.toLowerCase());
 					var pnpMatches = !!(port.pnpId && (port.pnpId.indexOf('VID_' + vid.toUpperCase()) >= 0) && (port.pnpId.indexOf('PID_' + pid.toUpperCase()) >= 0));
+					var serialNumberMatches = port.serialNumber && port.serialNumber.indexOf(serialNumber) >= 0;
 
-					if (usbMatches || pnpMatches) {
+					if (usbMatches || pnpMatches || serialNumberMatches) {
 						return true;
 					}
 					return false;

--- a/lib/deviceSpecs/specifications.js
+++ b/lib/deviceSpecs/specifications.js
@@ -2,7 +2,8 @@
 
 module.exports = {
 
-	'1d50:607f': { // Core
+	'1d50:607f': {
+		productName: 'Core',
 		tcpServerKey: {
 			address: '0x00001000',
 			size: 2048,
@@ -34,13 +35,14 @@ module.exports = {
 		},
 		serial: {
 			vid: '1d50',
-			pid: '607d'
+			pid: '607d',
+			serialNumber: 'Spark_Core'
 		},
-		productName: 'Core',
 		defaultProtocol: 'tcp',
 		productId: 0
 	},
-	'2b04:d006': { // Photon
+	'2b04:d006': {
+		productName: 'Photon',
 		tcpServerKey: {
 			address: '2082',
 			size: 512,
@@ -100,13 +102,14 @@ module.exports = {
 		},
 		serial: {
 			vid: '2b04',
-			pid: 'c006'
+			pid: 'c006',
+			serialNumber: 'Particle_Photon'
 		},
-		productName: 'Photon',
 		defaultProtocol: 'tcp',
 		productId: 6
 	},
-	'2b04:d008': { // P1
+	'2b04:d008': {
+		productName: 'P1',
 		tcpServerKey: {
 			address: '2082',
 			size: 512,
@@ -164,13 +167,14 @@ module.exports = {
 		},
 		serial: {
 			vid: '2b04',
-			pid: 'c008'
+			pid: 'c008',
+			serialNumber: 'Particle_P1'
 		},
-		productName: 'P1',
 		defaultProtocol: 'tcp',
 		productId: 8
 	},
-	'2b04:d00a': { // Electron
+	'2b04:d00a': {
+		productName: 'Electron',
 		tcpServerKey: {
 			address: '2082',
 			size: 512,
@@ -233,9 +237,9 @@ module.exports = {
 		},
 		serial: {
 			vid: '2b04',
-			pid: 'c00a'
+			pid: 'c00a',
+			serialNumber: 'Particle_Electron'
 		},
-		productName: 'Electron',
 		defaultProtocol: 'udp',
 		productId: 10
 	}


### PR DESCRIPTION
On (at least my) Linux Ubuntu 15.10, the reported vendor ID and product ID are the bus IDs instead of the device IDs. As a backup to the VID and PID identification, do a string matching on the `serialNumber` reported by the `serialport` module.

The expected strings for the Core, Photon and Electron are:
```
serialNumber: 'Spark_Devices_Spark_Core_with_WiFi_6D7238764957',
serialNumber: 'Particle_Photon_with_WiFi_00000000050C',
serialNumber: 'Particle_Electron_00000000050C',
```

Fixes #190