### PR TITLE
Connect to wifi network on Linux during setup

### DIFF
--- a/commands/WirelessCommand/WiFiManager.js
+++ b/commands/WirelessCommand/WiFiManager.js
@@ -3,7 +3,8 @@
 var _ = require('lodash');
 var os = require('os');
 var connect = {
-	'darwin': require('./connect/darwin')
+	'darwin': require('./connect/darwin'),
+	'linux': require('./connect/linux')
 };
 
 function WiFiManager(opts) {

--- a/commands/WirelessCommand/connect/linux.js
+++ b/commands/WirelessCommand/connect/linux.js
@@ -1,0 +1,85 @@
+var spawn = require('child_process').spawn;
+var wifiCli = '/usr/bin/nmcli';
+
+function runCommand(cmd, args, cb) {
+	var argArray = args.split(' ');
+
+	var s = spawn(cmd, argArray, {
+		stdio: ['ignore', 'pipe', 'pipe']
+	});
+
+	var stdout = '';
+	s.stdout.on('data', function (data) {
+		stdout += data;
+	});
+
+	var stderr = '';
+	s.stderr.on('data', function (data) {
+		stderr += data;
+	});
+
+	s.on('close', function (code) {
+		cb(code, stdout, stderr);
+	});
+}
+
+function getCurrentNetwork(cb) {
+	var currentNetworkParams = "--terse --fields NAME,TYPE connection show --active";
+
+	runCommand(wifiCli, currentNetworkParams, function (err, stdout, stderr) {
+		if(err || stderr) {
+			return cb(err || stderr);
+		}
+
+		var wifiType = "802-11-wireless";
+		var lines = stdout.split('\n');
+		for(var i = 0; i < lines.length; i++) {
+			var fields = lines[i].split(":");
+			var ssid = fields[0];
+			var type = fields[1];
+			if(type === wifiType) {
+				return cb(null, ssid);
+			}
+		}
+
+		cb();
+	});
+}
+
+function connect(opts, cb) {
+	function reconnect() {
+		var connectionDoesNotExistError = 10;
+		var reconnectParams = 'connection up id ' + opts.ssid;
+		runCommand(wifiCli, reconnectParams, function (err, stdout, stderr) {
+			if(err == connectionDoesNotExistError) {
+				return newConnect();
+			} else if(err || stderr) {
+				return cb(err || stderr);
+			}
+
+			cb(null, opts);
+		});
+	}
+
+	function newConnect() {
+		var newConnectParams = 'device wifi connect ' + opts.ssid;
+		if(opts.password) {
+			newConnectParams += ' password ' + opts.password;
+		}
+
+		runCommand(wifiCli, newConnectParams, function (err, stdout, stderr) {
+			if(err || stderr) {
+				return cb(err || stderr);
+			}
+
+			cb(null, opts);
+		});
+	}
+
+	reconnect();
+};
+
+module.exports = {
+	connect: connect,
+	getCurrentNetwork: getCurrentNetwork
+};

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "latest-version": "^2.0.0",
     "lodash": "^3.10.1",
     "moment": "^2.9.0",
-    "node-wifiscanner2": "^1.1.1",
+    "node-wifiscanner2": "^1.2.0",
     "request": "^2.46.0",
     "semver": "^5.1.0",
     "serialport": "^2.0.1",


### PR DESCRIPTION
Use the NetworkManager CLI (the standard Linux network configuration tool suite on Fedora, Debian, Ubuntu, Gentoo, CentOS or openSUSE) to switch to the Photon AP and reconnect to the wifi

Needs spark/node-wifiscanner#1 to be merged and a new version of node-wifiscanner2 to be added to the Particle CLI package.json in order for the WiFi scanning to work.

Tested on Ubuntu 15.10