### PR TITLE
Warn user when variable/function name is too long

### DIFF
--- a/commands/FunctionCommand.js
+++ b/commands/FunctionCommand.js
@@ -45,6 +45,8 @@ FunctionCommand.prototype = extend(BaseCommand.prototype, {
 	name: 'function',
 	description: 'call functions on your device',
 
+	maxNameLength: 12,
+
 	init: function () {
 		this.addOption('list', this.listFunctions.bind(this), 'List functions provided by your device(s)');
 		this.addOption('call', this.callFunction.bind(this), 'Call a particular function on a device');
@@ -96,6 +98,11 @@ FunctionCommand.prototype = extend(BaseCommand.prototype, {
 		var api = new ApiClient();
 		if (!api.ready()) {
 			return -1;
+		}
+
+		if(functionName.length > this.maxNameLength) {
+			console.log('Function name is too long (maximum ' + this.maxNameLength + ' characters)');
+			return when.reject();
 		}
 
 		return api.callFunction(deviceId, functionName, funcParam).then(

--- a/commands/VariableCommand.js
+++ b/commands/VariableCommand.js
@@ -52,6 +52,7 @@ VariableCommand.prototype = extend(BaseCommand.prototype, {
 	name: 'variable',
 	description: 'retrieve and monitor variables on your device',
 
+	maxNameLength: 12,
 
 	init: function () {
 		this.addOption('list', this.listVariables.bind(this), 'Show variables provided by your device(s)');
@@ -123,6 +124,11 @@ VariableCommand.prototype = extend(BaseCommand.prototype, {
 		var that = this;
 		if (!_.isArray(deviceId)) {
 			deviceId = [ deviceId ];
+		}
+
+		if(variableName.length > this.maxNameLength) {
+			console.log('Variable name is too long (maximum ' + this.maxNameLength + ' characters)');
+			return when.reject();
 		}
 
 		var api = new ApiClient();
@@ -272,6 +278,11 @@ VariableCommand.prototype = extend(BaseCommand.prototype, {
 		}
 		this.checkArguments(arguments);
 
+		if(variableName && variableName.length > this.maxNameLength) {
+			console.log('Variable name is too long (maximum ' + this.maxNameLength + ' characters)');
+			return when.reject();
+		}
+
 		function disambiguate() {
 			if (deviceId === 'all') {
 				deviceId = null;
@@ -292,7 +303,7 @@ VariableCommand.prototype = extend(BaseCommand.prototype, {
 			function checkVariable() {
 				self._getValue(result.deviceIds, result.variableName).ensure(function () {
 					setTimeout(checkVariable, delay);
-				});
+				}).catch(function() {});
 			}
 			checkVariable();
 		}).catch(function (err) {


### PR DESCRIPTION
See forum discussion http://community.particle.io/t/function-not-found/20189

I've done this often too: register a function/variable in code with a long name without checking the return value, then scratch my head for a while to figure out why I can't request its value.

This also adds a catch-all clause to monitorVariables to avoid this message when an error occurs:
```
Hit CTRL-C to stop!
Error: Variable not found
Potentially unhandled rejection [2] undefined (WARNING: non-Error used)
Error: Variable not found
Potentially unhandled rejection [4] undefined (WARNING: non-Error used)
Error: Variable not found
Potentially unhandled rejection [6] undefined (WARNING: non-Error used)
```