### PR TITLE
add: least heard for electron

### DIFF
--- a/commands/CloudCommands.js
+++ b/commands/CloudCommands.js
@@ -881,8 +881,15 @@ CloudCommand.prototype = extend(BaseCommand.prototype, {
 					name = chalk.cyan.dim(name);
 				}
 
-				var status = name + ' [' + device.id + ']' + deviceType + ' is ';
-				status += (device.connected) ? 'online' : 'offline';
+				var status = name + ' [' + device.id + ']' + deviceType;
+				if (deviceType === ' (Electron)') {
+					lines.push(status);
+					var lastHeard = new Date(device.last_heard).toLocaleString();
+					status = '  Last heard: ' + lastHeard;
+				} else {
+					status += ' is ';
+					status += (device.connected) ? 'online' : 'offline';
+				}
 				lines.push(status);
 
 				formatVariables(device.variables, lines);


### PR DESCRIPTION
- shows in the locale GMT
- aligned with var/function tabspace

Example:


```
elec2g [xxx] (Electron)
  Last heard: Sun Feb 21 2016 08:41:36 GMT+0800 (SGT)
  Variables:
    soc (double)
    test (string)
  Functions:
    int digitalread(String args) 
    int digitalwrite(String args) 
    int analogread(String args) 
    int analogwrite(String args) 
elec3g [xx] (Electron)
  Last heard: Thu Feb 11 2016 10:00:25 GMT+0800 (SGT)
  Variables:
    test (string)
    soc (double)
  Functions:
    int digitalread(String args) 
    int digitalwrite(String args) 
    int analogread(String args) 
    int analogwrite(String args) 
oled [xx] (Photon) is online
  Functions:
    int stime(String args) 
    int reset(String args) 

````
Signed-off-by: Kenneth Lim <kennethlimcp@gmail.com>