### PR TITLE
device: add duo support

### DIFF
--- a/lib/deviceSpecs/specifications.js
+++ b/lib/deviceSpecs/specifications.js
@@ -242,6 +242,51 @@ module.exports = {
 		},
 		defaultProtocol: 'udp',
 		productId: 10
+	},
+	'2b04:d058': {
+		productName: 'Duo',
+		tcpServerKey: {
+			address: '2082',
+			size: 512,
+			format: 'der',
+			alt: '1',
+			alg: 'rsa',
+			addressOffset: 384,
+			portOffset: 450
+		},
+		tcpPrivateKey: {
+			address: '34',
+			size: 612,
+			format: 'der',
+			alt: '1',
+			alg: 'rsa'
+		},
+		factoryReset: {
+			address: '0x00140000',
+			alt: '2'
+		},
+		userFirmware: {
+			address: '0x080C0000',
+			alt: '0'
+		},
+		systemFirmwareOne: {
+			address: '0x08020000',
+			alt: '0'
+		},
+		systemFirmwareTwo: {
+			address: '0x08040000',
+			alt: '0'
+		},
+		knownApps: {
+
+		},
+		serial: {
+			vid: '2b04',
+			pid: 'c058',
+			serialNumber: 'RedBear_Duo'
+		},
+		defaultProtocol: 'tcp',
+		productId: 88
 	}
 };
 


### PR DESCRIPTION
- DFU works (tested sys1, sys2, user, factory)
- Serial works (wifi, inspect, identify)

- Not sure about the public/private keys address location though
- serialNumber: 'RedBear_Duo' is not verfied as this shows up in linux but should be correct based on https://github.com/redbear/firmware/blob/duo/bootloader/src/stm32f2xx/usbd_desc.c
- fixes https://github.com/spark/particle-cli/issues/173

Signed-off-by: Kenneth Lim <kennethlimcp@gmail.com>