### PR TITLE
bump serialport dependency version for Node.js v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 - '0.12'
 - '4'
 - '5'
+- '6'
 sudo: false
 script:
   - npm run lint

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node-wifiscanner2": "^1.1.1",
     "request": "^2.46.0",
     "semver": "^5.1.0",
-    "serialport": "^2.0.1",
+    "serialport": "^3.1.1",
     "softap-setup": "^1.1.4",
     "temp": "^0.8.3",
     "when": "^3.7.2",


### PR DESCRIPTION
On Node.js v6, serialport was logging a huge warning for every particle-cli command, even ones that were unrelated to the serial port. See https://github.com/voodootikigod/node-serialport/issues/780 for details.

This change just bumps the serialport dependency to the latest release, which resolves the issue.

All the tests still pass and I did some basic manual testing and didn't see any issues.