### PR TITLE
Bugfix

### DIFF
--- a/lib/interpreter.js
+++ b/lib/interpreter.js
@@ -73,7 +73,7 @@ Interpreter.prototype = {
 	},
 
 	setupTerminal: function () {
-		if(process.stdout._handle.setBlocking) {
+		if(process.stdout._handle !== undefined && process.stdout._handle.setBlocking) {
 			process.stdout._handle.setBlocking(true);
 		}
 	},


### PR DESCRIPTION
prevents calling `process.stdout._handle.setBlocking` when `_handle` is undefined (perhaps due to being run when there is no tty present?).

I was going to file an issue for this, but decided a PR would probably be easier for all parties :).