### PR TITLE
Feature/library list

### DIFF
--- a/oldlib/prompts.js
+++ b/oldlib/prompts.js
@@ -97,7 +97,7 @@ var that = {
 		return dfd.promise;
 	},
 
-	enterToContinueControLCToExit(message) {
+	enterToContinueControlCToExit(message) {
 		if (!message) {
 			message = 'Press ENTER for next page, CTRL-C to exit.';
 		}

--- a/oldlib/prompts.js
+++ b/oldlib/prompts.js
@@ -18,6 +18,9 @@ var that = {
 				input: process.stdin,
 				output: process.stdout
 			});
+			that._prompt.on("SIGINT", function () {
+				process.emit("SIGINT");
+			});
 		}
 		return that._prompt;
 	},
@@ -91,6 +94,24 @@ var that = {
 			stdin.removeListener('data', onStdinData);
 		});
 
+		return dfd.promise;
+	},
+
+	enterToContinueControLCToExit(message) {
+		if (!message) {
+			message = 'Press ENTER for next page, CTRL-C to exit.';
+		}
+		var dfd = when.defer();
+		var prompt = that.getPrompt();
+		prompt.question(message, function (value) {
+			that.closePrompt();
+			dfd.resolve(true);
+		});
+		process.on('SIGINT', function () {
+			that.closePrompt();
+			console.log();
+			dfd.resolve(false);
+		});
 		return dfd.promise;
 	},
 

--- a/src/cli/library_list.js
+++ b/src/cli/library_list.js
@@ -50,10 +50,15 @@ export class CLILibraryListCommandSite extends LibraryListCommandSite {
 	 */
 	settings() {
 		const result = {};
-		if (this.argv.filter) {
-			result.filter = this.argv.filter;
-		}
+		this._add(result, 'filter');
+		this._add(result, 'limit');
 		return result;
+	}
+
+	_add(target, param) {
+		if (this.argv[param]) {
+			target[param] = this.argv[param];
+		}
 	}
 
 	sectionNames() {
@@ -153,6 +158,14 @@ export default ({lib, factory, apiJS}) => {
 				required: false,
 				boolean: true,
 				description: 'Prints a single page of libraries without prompting'
+			},
+			'page': {
+				required: false,
+				description: 'Start the listing at the given page number'
+			},
+			'limit': {
+				required: false,
+				description: 'The number of items to show per page'
 			}
 		},
 		params: '[sections...]',

--- a/src/cli/library_list.js
+++ b/src/cli/library_list.js
@@ -175,7 +175,7 @@ export default ({lib, factory, apiJS}) => {
 			let count = 0;
 
 			function prompForNextPage() {
-				return prompt.enterToContinueControLCToExit();
+				return prompt.enterToContinueControlCToExit();
 			}
 
 			function runPage() {

--- a/src/cli/library_list.js
+++ b/src/cli/library_list.js
@@ -134,7 +134,7 @@ export class CLILibraryListCommandSite extends LibraryListCommandSite {
 		console.log(chalk.bold(heading)+page);
 		if (libraries.length) {
 			for (let library of libraries) {
-				this.showLibrary(name, library);
+				this.showLibrary(section, library);
 			}
 		} else {
 			console.log(chalk.grey('No libraries to show in this section.'));

--- a/src/cli/library_ui.js
+++ b/src/cli/library_ui.js
@@ -3,19 +3,22 @@ import chalk from 'chalk';
 export function formatLibrary(library, excludeBadges=[]) {
 	let badges = [];
 
-	if (library.verified && !excludeBadges.verified) {
-		badges.push(chalk.green('[verified] '));
+	if (library.official && !excludeBadges.official) {
+		badges.push(chalk.green('[official] '));
+	}
+	else {
+		if (library.verified && !excludeBadges.verified) {
+			badges.push(chalk.green('[verified] '));
+		}
 	}
 
-	let privateBadge = false;
 	if (library.visibility==='private' && !excludeBadges.private) {
 		badges.push(chalk.blue('[private] '));
-		privateBadge = true;
 	}
-
-	// at present, a library that is private is implicitly mine
-	if (library.mine && !privateBadge && !excludeBadges.mine) {
-		badges.push(chalk.blue('[mine] '));
+	else {
+		if (library.mine && !excludeBadges.mine) {
+			badges.push(chalk.blue('[mine] '));
+		}
 	}
 
 	const badgesText = badges.join('');


### PR DESCRIPTION
- allows the sections to list to be defined after the command `particle library list [sections...]`
- `--filter` parameter to filter the results by name
- pagination: after each page, hit enter for next, or CTRL+C to exit
- `--non-interactive` flag to turn off automatic pagination
- '--limit'  to specify the page size
- '--page' to specify the start page (1 based)