### PR TITLE
project init dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "moment": "^2.9.0",
     "node-wifiscanner2": "^1.2.0",
     "particle-api-js": "^6.4.1",
-    "particle-commands": "^0.2.4",
+    "particle-commands": "^0.2.5",
     "particle-library-manager": "^0.1.4",
     "request": "https://github.com/spark/request/releases/download/v2.75.1-relativepath.1/request-2.75.1-relativepath.1.tgz",
     "semver": "^5.1.0",

--- a/src/cli/library_add.js
+++ b/src/cli/library_add.js
@@ -41,7 +41,7 @@ export class CLILibraryAddCommandSite extends LibraryAddCommandSite {
 }
 
 export default ({lib, factory, apiJS}) => {
-	factory.createCommand(lib, 'add', 'Add a library to the current project.', {
+	factory.createCommand(lib, 'add', 'Adds a library to the current project', {
 		options: {},
 		params: '<name>',
 

--- a/src/cli/library_init.js
+++ b/src/cli/library_init.js
@@ -41,7 +41,7 @@ export class CLILibraryInitCommandSite extends LibraryInitCommandSite {
 
 
 export default ({lib, factory}) => {
-	factory.createCommand(lib, 'init', 'Initializes a new library in the specified or current directory.', {
+	factory.createCommand(lib, 'create', 'Creates a new library in the specified or current directory', {
 		options: {
 			'name': {
 				required: false,

--- a/src/cli/library_install.js
+++ b/src/cli/library_install.js
@@ -98,7 +98,7 @@ export default ({lib, factory, apiJS}) => {
 		handler: (argv) => libraryInstallHandler(argv, apiJS),
 	});
 
-	factory.createCommand(lib, 'copy', 'copies a library to the current project', {
+	factory.createCommand(lib, 'copy', 'Copies a library to the current project', {
 		options: {},
 		params: '[name]',
 		handler: function LibraryCopyHandler(argv) {

--- a/src/cli/library_migrate.js
+++ b/src/cli/library_migrate.js
@@ -83,7 +83,7 @@ export class CLILibraryMigrateCommandSite extends CLIBaseLibraryMigrateCommandSi
 
 
 export default ({lib, factory}) => {
-	factory.createCommand(lib, 'migrate', 'Migrates a local library from v1 to v2 format.', {
+	factory.createCommand(lib, 'migrate', 'Migrates a local library from v1 to v2 format', {
 		options: {
 			test: {
 				alias: 'dryrun',

--- a/src/cli/library_publish.js
+++ b/src/cli/library_publish.js
@@ -39,7 +39,7 @@ export class CLILibraryPublishCommandSite extends LibraryPublishCommandSite {
 }
 
 export default ({lib, factory, apiJS}) => {
-	factory.createCommand(lib, 'publish', 'publishes a library', {
+	factory.createCommand(lib, 'publish', 'Publishes a private library, making it public', {
 		options: {},
 		params: '[name]',
 

--- a/src/cli/library_search.js
+++ b/src/cli/library_search.js
@@ -43,7 +43,7 @@ export class CLILibrarySearchCommandSite extends LibrarySearchCommandSite {
 
 
 export default ({lib, factory, apiJS}) => {
-	factory.createCommand(lib, 'search', 'searches available libraries', {
+	factory.createCommand(lib, 'search', 'Searches available libraries', {
 		options: {
 		},
 		params: '<name>',

--- a/src/cli/library_upload.js
+++ b/src/cli/library_upload.js
@@ -45,7 +45,7 @@ export class CLILibraryContributeCommandSite extends LibraryContributeCommandSit
 }
 
 export default ({lib, factory, apiJS}) => {
-	factory.createCommand(lib, 'upload', 'uploads a private version of a library', {
+	factory.createCommand(lib, 'upload', 'Uploads a private version of a library', {
 		options: {
 			'dryRun': {
 				required: false,

--- a/src/cli/project_init.js
+++ b/src/cli/project_init.js
@@ -1,16 +1,109 @@
-import {ProjectInitCommand, ProjectInitCommandSite} from '../cmd';
-
+import {ProjectInitCommand, ProjectInitCommandSite, Projects} from '../cmd';
+import {validateField} from 'particle-library-manager';
+import path from 'path';
 import log from '../app/log';
 import chalk from 'chalk';
+import prompt from '../../oldlib/prompts';
+
+
+// todo - this is pulled from validating_editor in particle-dev-libraries. Please refactor/DRY.
+
+function validationMessage(validationResult, fieldName) {
+	return fieldName+' '+validationResult.errors[fieldName];
+}
+
+function fieldValidator(fieldName) {
+	const validator = (value) => {
+		const result = validateField(fieldName, value);
+		return (result && result.valid) ?
+			'' : validationMessage(result, fieldName);
+	};
+	return validator;
+}
+
+function yesNoValidator() {
+	const validator = (value) => {
+		if (!value || (value!=='Y' && value!=='y' && value!=='N' && value!=='n')) {
+			return 'Please answer "y" or "n" - you typed '+value;
+		}
+	};
+	return validator;
+}
+
 
 class CLIProjectInitCommandSite extends ProjectInitCommandSite {
-	constructor(dir) {
+	constructor({name, directory}) {
 		super();
-		this.dir = dir;
+		this._name = name;
+		this._dir = directory;
+	}
+
+	/**
+	 * Has a dialog with the user. Returns a truthy value if project init should continue.
+	 * “What would you like to call your project?”
+	 Then, you are asked to choose where you would like to save your project
+	 “Would you like to create your project in the default project directory? (Y/n)
+	 If you answer Y, the project directory is created under /home/particle/projects/myproject, and the CLI replies, “A new project named “myproject” was successfully created in home/particle/projects/myproject
+	 Then, you are automatically taken to the new project directory in your current session
+	 If you answer N to the first question, the CLI asks, “Would you like to create your project in <current path>? Type “n” to cancel. (Y/n)
+	 If you answer Y, the project directory is created under <current path>/myproject
+	 If you answer anything else, the `project init` process is cancelled
+
+	 */
+	dialog() {
+		const promptForName = () => {
+			return this._name || this.prompt('What would you like to call your project? [myproject]', 'myproject', fieldValidator('name'));
+		};
+
+		function isYes(result) {
+			return (result||'').toLowerCase()==='y';
+		}
+
+		const promptForLocation = (commonLocation, currentLocation) => {
+			return this._dir ||
+				this.prompt('Would you like to create your project in the default project directory? [Y/n]', 'Y', yesNoValidator())
+					.then(result => {
+						if (isYes(result)) {
+							return commonLocation;
+						} else {
+							return this.prompt(`Would you like to create your project in ${currentLocation}? Type “n” to cancel. [Y/n]`, 'Y', yesNoValidator())
+								.then((result) => {
+									return (isYes(result)) ? currentLocation : '';
+								});
+						}
+					});
+		};
+
+		return Promise.resolve()
+			.then(() => promptForName())
+			.then((name) => {
+				this._name = name;
+				if (name) {
+					return promptForLocation(new Projects().myProjectsFolder(), process.cwd());
+				}
+			})
+			.then(directory => {
+				this._dir = directory;
+				return this._dir && this._name;   // are we ready?
+			});
+	}
+
+	/**
+	 * Prompts the user to enter a value
+	 * @param {string} message       The message to prompt with
+	 * @param {string} value         The default value
+     * @param {function(value)}         validator The validator that is used to validate the response.
+	 */
+	prompt(message, value, validator) {
+		return prompt.promptAndValidate(message, value, validator);
+	}
+
+	name() {
+		return this._name;
 	}
 
 	directory() {
-		return this.dir;
+		return path.join(this._dir, this._name);
 	}
 
 	filesystem() {
@@ -65,14 +158,24 @@ export default ({project, factory}) => {
 
 	// todo - move library add to its own module
 	factory.createCommand(project, 'init', 'Initialize a new project in the current or specified directory.', {
-		options: {},
+		options: {
+			'name' : {
+				required: false,
+				description: 'provide a name for the project'
+			}
+		},
 		params: '[dir]',
 
 		handler: function projectInitandler(argv) {
 			const dir = argv.params.dir || process.cwd();
 			const site = new CLIProjectInitCommandSite(dir);
 			const cmd = new ProjectInitCommand();
-			return site.run(cmd);
+			return site.dialog()
+				.then((ready) => {
+					if (ready) {
+						return site.run(cmd);
+					}
+				});
 		}
 	});
 };

--- a/src/cli/project_init.js
+++ b/src/cli/project_init.js
@@ -65,12 +65,13 @@ class CLIProjectInitCommandSite extends ProjectInitCommandSite {
 					.then(result => {
 						if (isYes(result)) {
 							return commonLocation;
-						} else {
-							return this.prompt(`Would you like to create your project in ${chalk.bold(currentLocation)}? Type “n” to cancel. [Y/n]`, 'Y', yesNoValidator())
-								.then((result) => {
-									return (isYes(result)) ? currentLocation : '';
-								});
 						}
+					})
+					.then(location => {
+						return location || this.prompt(`Would you like to create your project in ${chalk.bold(currentLocation)}? Type “n” to cancel. [Y/n]`, 'Y', yesNoValidator())
+							.then((result) => {
+								return (isYes(result)) ? currentLocation : '';
+							});
 					});
 		};
 

--- a/src/cli/project_init.js
+++ b/src/cli/project_init.js
@@ -66,7 +66,7 @@ class CLIProjectInitCommandSite extends ProjectInitCommandSite {
 						if (isYes(result)) {
 							return commonLocation;
 						} else {
-							return this.prompt(`Would you like to create your project in ${currentLocation}? Type “n” to cancel. [Y/n]`, 'Y', yesNoValidator())
+							return this.prompt(`Would you like to create your project in ${chalk.bold(currentLocation)}? Type “n” to cancel. [Y/n]`, 'Y', yesNoValidator())
 								.then((result) => {
 									return (isYes(result)) ? currentLocation : '';
 								});
@@ -157,7 +157,7 @@ class CLIProjectInitCommandSite extends ProjectInitCommandSite {
 export default ({project, factory}) => {
 
 	// todo - move library add to its own module
-	factory.createCommand(project, 'init', 'Initialize a new project in the current or specified directory.', {
+	factory.createCommand(project, 'create', 'Create a new project in the current or specified directory.', {
 		options: {
 			'name' : {
 				required: false,


### PR DESCRIPTION
Prompts the user for a name and directory as detailed in the product spec.
Also makes the library command descriptions consistent.
renames `init` to `create`.