### PR TITLE
add: test case for flashing knownApp

### DIFF
--- a/accept/features/cloud_flash.feature
+++ b/accept/features/cloud_flash.feature
@@ -22,3 +22,9 @@ Feature: cloud flash
     # FIXME: the CLI doesn't wait for the flash to finish so we delay to let the flash complete
     And I run `sleep 1`
 
+  Scenario: as a user, I can flash a known app to a device
+    When I wait until the device "cli_test_photon" is online
+    When I run particle "flash cli_test_photon tinker"
+    Then the stdout should contain "attempting to flash firmware"
+    And the stdout should contain "Flash device OK"
+    And I run `sleep 1`


### PR DESCRIPTION
Related to: https://github.com/spark/particle-cli/issues/331

This PR probably did not handle the flashing of knownApp: https://github.com/spark/particle-cli/commit/eadd6790e83c19f180557a0ac8e4548ebd0d1eb3

Output from `fileMapping` using a knownApp: 
```
{ list: [ '/Users/kennethlimcp/Desktop/particle/particle-cli/binaries/photon_tinker.bin' ] }
```

Output from `fileMapping` for source files:
```
 { basePath: '/Users/kennethlimcp/Desktop/particle/particle-cli',
  map: { 'test.ino': '../../test/test.ino' } }

```


Signed-off-by: Kenneth Lim <kennethlimcp@gmail.com>