### PR TITLE
adds a `—yes` parameter to skip the bandwidth prompt

### DIFF
--- a/oldlib/ApiClient.js
+++ b/oldlib/ApiClient.js
@@ -536,18 +536,22 @@ ApiClient.prototype = {
 		return result;
 	},
 
-	_addFilesToCompile: function (r, fileMapping, targetVersion, platform_id) {
-		var form = r.form();
+	_populateFileMapping(fileMapping) {
 		if (!fileMapping.map) {
-			fileMapping.map = {}
+			fileMapping.map = {};
 			if (fileMapping.list) {
 				for (var i = 0; i < fileMapping.list.length; i++) {
-					var item = fileMapping.list[i]
+					var item = fileMapping.list[i];
 					fileMapping.map[item] = item;
 				}
 			}
 		}
+		return fileMapping;
+	},
 
+	_addFilesToCompile: function (r, fileMapping, targetVersion, platform_id) {
+		var form = r.form();
+		this._populateFileMapping(fileMapping);
 		var list = Object.keys(fileMapping.map);
 		for (var i = 0, n = list.length; i < n; i++) {
 			var relativeFilename = list[i];


### PR DESCRIPTION
addresses https://github.com/spark/particle-cli/issues/287

```
$particle flash electron2 tinker --yes
! Skipping Bandwidth Prompt !
attempting to flash firmware to your device electron2
...
```

This also fixes an error due to a missing `.map` property on `fileMapping` when flashing a known app. (seems there are multiple paths for known apps - we fixed one just a few weeks ago, this PR fixes the other one.)

