### PR TITLE
native module preemptive loading

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -100,7 +100,10 @@ var settings = {
 			systemFirmwareThree: 'system-part1-0.6.0-electron.bin'
 		}
 	},
-	commandMappings: path.join(__dirname, 'mappings.json')
+	commandMappings: path.join(__dirname, 'mappings.json'),
+	nativeModules: [
+		'serialport'
+	]
 };
 
 function envValue(varName, defaultValue) {

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -212,10 +212,32 @@ export class CLI {
 		return false;
 	}
 
+	loadNativeModules(modules) {
+		let errors = [];
+		for (let module of modules) {
+			try {
+				require(module);
+			} catch (err) {
+				errors.push(`Error loading module '${module}': ${err.message}`);
+			}
+		}
+		return errors;
+	}
+
 	run(args) {
 		settings.transitionSparkProfiles();
 		settings.whichProfile();
 		settings.loadOverrides();
+
+		const nativeErrors = this.loadNativeModules(settings.nativeModules);
+		if (nativeErrors.length) {
+			const log = require('./log');
+			for (let error of nativeErrors) {
+				log.error(error);
+			}
+			log.fatal('Please reinstall the CLI again to ensure the module is installed to match the version of node.');
+			return;
+		}
 
 		settings.disableUpdateCheck = this.hasArg('--no-update-check', args);
 		const force = this.hasArg('--force-update-check', args);

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -7,6 +7,7 @@ import * as cliargs from './nested-yargs';
 import commands from '../cli';
 import * as settings from '../../settings';
 import when from 'when';
+import chalk from 'chalk';
 
 export class CLI {
 
@@ -235,7 +236,7 @@ export class CLI {
 			for (let error of nativeErrors) {
 				log.error(error);
 			}
-			log.fatal('Please reinstall the CLI again to ensure the module is installed to match the version of node.');
+			log.fatal(`Please reinstall the CLI again using ${chalk.bold("npm install -g particle-cli")}`);
 			return;
 		}
 


### PR DESCRIPTION
Loads native modules as part of startup to capture any loading issues. If they fail to load, the user is prompted to reinstall the CLI. fixes #322