### PR TITLE
Feature/serial setup

### DIFF
--- a/commands/SerialCommand.js
+++ b/commands/SerialCommand.js
@@ -955,7 +955,7 @@ SerialCommand.prototype = extend(BaseCommand.prototype, {
 				if (deviceName) {
 					__oldapi.renameDevice(deviceId, deviceName).then(function () {
 						console.log();
-						console.log(arrow, 'Your Photon has been bestowed with the name', chalk.bold.cyan(deviceName));
+						console.log(arrow, 'Your Photon has been given the name', chalk.bold.cyan(deviceName));
 						console.log(arrow, "Congratulations! You've just won the internet!");
 						console.log();
 						self.exit();

--- a/commands/SerialCommand.js
+++ b/commands/SerialCommand.js
@@ -632,7 +632,7 @@ SerialCommand.prototype = extend(BaseCommand.prototype, {
 
 	_promptWifiScan(wifi, device) {
 		var self = this;
-		inquirer.prompt([
+		self.prompt([
 			{
 				type: 'confirm',
 				name: 'scan',
@@ -674,7 +674,7 @@ SerialCommand.prototype = extend(BaseCommand.prototype, {
 		var ssids = _.pluck(networks, 'ssid');
 		ssids = this._removePhotonNetworks(ssids);
 
-		inquirer.prompt([
+		self.prompt([
 			{
 				type: 'list',
 				name: 'ap',
@@ -858,7 +858,7 @@ SerialCommand.prototype = extend(BaseCommand.prototype, {
 
 			console.log(arrow, 'Obtained magical secure claim code.');
 			console.log();
-			return self.sendClaimCode(device, dat.claim_code, true)
+			return self.sendClaimCode(device, dat.claim_code)
 				.then(function() {
 					console.log('Claim code set. Now setting up Wi-Fi');
 					// todo - add additional commands over USB to have the device scan for Wi-Fi
@@ -1038,7 +1038,7 @@ SerialCommand.prototype = extend(BaseCommand.prototype, {
 	 *          promise: the deferred result (call resolve/reject)
 	 *          next: the response callback, should be called with (response) to send a response.
 	 *              Response can be undefined
-	 *
+	 * $param {Boolean} nologging   when truthy, logging is disabled.
 	 * @returns {Promise}
 	 */
 	doSerialInteraction: function(device, command, interactions, noLogging) {
@@ -1293,10 +1293,10 @@ SerialCommand.prototype = extend(BaseCommand.prototype, {
 
 			serialPort.flush(function() {
 				serialPort.on('data', function(data) {
-					log.serialOutput(data.toString());
+					//log.serialOutput(data.toString());
 				});
 
-				st.start();
+				st.start(true);
 				serialPort.write('w', function() {
 					serialPort.drain();
 				});

--- a/commands/SerialCommand.js
+++ b/commands/SerialCommand.js
@@ -548,6 +548,10 @@ SerialCommand.prototype = extend(BaseCommand.prototype, {
 		// TODO remove once we have verbose flag
 		settings.verboseOutput = true;
 
+		function parameterMissing(param) {
+			return 'The "'+param+'" parameter was missing. Please specify a filename of a valid JSON object, ie {"network":"myNetwork","security":"WPA_AES","channel":2,"password":"mySecret!"}';
+		}
+
 		var wifi = when.defer();
 		this.checkArguments(arguments);
 
@@ -586,10 +590,6 @@ SerialCommand.prototype = extend(BaseCommand.prototype, {
 
                 // Directly
                 var obj = JSON.parse(fs.readFileSync(json, "utf-8"));
-
-	            function parameterMissing(param) {
-		            return 'The "'+param+'" parameter was missing. Please specify a filename of a valid JSON object, ie {"network":"myNetwork","security":"WPA_AES","channel":2,"password":"mySecret!"}';
-	            }
 
                 if (!obj.hasOwnProperty('network') || obj.network.length < 2){
                     _jsonErr(parameterMissing('network'));

--- a/commands/SerialCommand.js
+++ b/commands/SerialCommand.js
@@ -522,8 +522,10 @@ SerialCommand.prototype = extend(BaseCommand.prototype, {
 				return self.error('Unable to scan for Wi-Fi networks. Do you have permission to do that on this system?');
 			}
 
+			// todo - if the prompt is auto answering, then only auto answer once, to prevent
+			// never ending loops
 			if (networkList.length === 0) {
-				inquirer.prompt([{
+				self.prompt([{
 					type: 'confirm',
 					name: 'rescan',
 					message: 'Uh oh, no networks found. Try again?',

--- a/commands/SetupCommand/index.js
+++ b/commands/SetupCommand/index.js
@@ -357,27 +357,38 @@ SetupCommand.prototype.findDevice = function() {
 			detectedPrompt(device.type, function setupPhotonChoice(ans) {
 
 				if (ans.setup) {
-
 					var macAddress;
 					self.newSpin('Getting device information...').start();
-					serial.getDeviceMacAddress(device).then(function(mac) {
 
-						macAddress = mac;
+					serial.supportsClaimCode(device).then(function (supported) {
+						if (supported) {
+							self.stopSpin();
+							console.log(
+								chalk.cyan('!'),
+								"The device supports setup via serial."
+							);
+							return serial.setup(device);
+						}
 
-					}, function() {
+						serial.getDeviceMacAddress(device).then(function(mac) {
 
-						// do nothing on rejection
+							macAddress = mac;
 
-					}).finally(function () {
+						}, function() {
 
-						self.stopSpin();
-						console.log(
-							chalk.cyan('!'),
-							"The Photon supports secure Wi-Fi setup. We'll try that first."
-						);
-						return wireless.list(macAddress, self.options.manual);
+							// do nothing on rejection
+
+						}).finally(function () {
+
+							self.stopSpin();
+							console.log(
+								chalk.cyan('!'),
+								"The Photon supports secure Wi-Fi setup. We'll try that."
+							);
+							return wireless.list(macAddress, self.options.manual);
+						});
+
 					});
-					return;
 				} else {
 					tryScan();
 				}
@@ -575,7 +586,7 @@ SetupCommand.prototype.prompt = function(prompts, cb) {
 	prompt(prompts, cb);
 };
 
-
+// todo - this is also duplicated in the WiFiCommand too...
 SetupCommand.prototype.exit = function() {
 
 	console.log();

--- a/commands/SetupCommand/index.js
+++ b/commands/SetupCommand/index.js
@@ -28,6 +28,10 @@ var strings = {
 	'helpForMoreInfo': 'Please try the `%s help` command for more information.'
 };
 
+function goodbye() {
+	console.log(arrow, 'Goodbye!');
+}
+
 // TODO: DRY this up somehow
 var cmd = path.basename(process.argv[1]);
 var alert = chalk.yellow('!');
@@ -325,9 +329,9 @@ SetupCommand.prototype.findDevice = function() {
 			if (ans.scan) {
 				return wireless.list();
 			}
-			console.log(arrow, 'Goodbye!');
-		};
-	});
+			goodbye();
+		}
+	}
 
 	function inspect(device) {
 
@@ -339,7 +343,7 @@ SetupCommand.prototype.findDevice = function() {
 				if (ans.setup) {
 					return self.setupCore(device);
 				}
-				console.log(arrow, 'Goodbye!');
+				goodbye();
 			});
 		} else if (device.type === 'Photon' || device.type === 'P1') {
 
@@ -376,7 +380,7 @@ SetupCommand.prototype.findDevice = function() {
 				if (ans.setup) {
 					return self.setupElectron(device);
 				}
-				console.log(arrow, 'Goodbye!');
+				goodbye();
 			});
 		}
 	}

--- a/commands/SetupCommand/index.js
+++ b/commands/SetupCommand/index.js
@@ -332,7 +332,7 @@ SetupCommand.prototype.findDevice = function() {
 
 		function scanChoice(ans) {
 			if (ans.scan) {
-				return wireless.list();
+				return wireless.list(undefined, self.options.manual);
 			}
 			goodbye();
 		}
@@ -374,7 +374,7 @@ SetupCommand.prototype.findDevice = function() {
 							chalk.cyan('!'),
 							"The Photon supports secure Wi-Fi setup. We'll try that first."
 						);
-						return wireless.list(macAddress);
+						return wireless.list(macAddress, self.options.manual);
 					});
 					return;
 				} else {
@@ -537,12 +537,11 @@ SetupCommand.prototype.checkArguments = function(args) {
 
 	// TODO: tryParseArgs?
 	if (!this.options.scan) {
+		this.options.scan = utilities.tryParseArgs(args, '--scan', null);
+	}
 
-		this.options.scan = utilities.tryParseArgs(
-			args,
-			'--scan',
-			null
-		);
+	if (!this.options.manual) {
+		this.options.manual = utilities.tryParseArgs(args, '--manual', null);
 	}
 };
 

--- a/commands/SetupCommand/index.js
+++ b/commands/SetupCommand/index.js
@@ -68,9 +68,7 @@ SetupCommand.prototype.setup = function setup(shortcut) {
 
 	this.checkArguments(arguments);
 
-	if (shortcut === 'wifi') {
-		return serial.configureWifi();
-	}
+	this.forceWiFi = !!(shortcut === 'wifi');
 
 	console.log(chalk.bold.cyan(utilities.banner()));
 	console.log(arrow, "Setup is easy! Let's get started...");
@@ -362,7 +360,7 @@ SetupCommand.prototype.findDevice = function() {
 					self.newSpin('Getting device information...').start();
 
 					serial.supportsClaimCode(device).then(function (supported) {
-						if (supported) {
+						if (supported && !self.forceWiFi) {
 							self.stopSpin();
 							console.log(
 								chalk.cyan('!'),

--- a/commands/SetupCommand/index.js
+++ b/commands/SetupCommand/index.js
@@ -272,6 +272,7 @@ SetupCommand.prototype.findDevice = function() {
 	var serial = this.cli.getCommandModule('serial');
 	var wireless = this.cli.getCommandModule('wireless');
 	wireless.prompt = this.prompt.bind(this);
+	serial.prompt = this.prompt.bind(this);
 
 	console.log();
 	console.log(

--- a/commands/SetupCommand/index.js
+++ b/commands/SetupCommand/index.js
@@ -22,7 +22,7 @@ var strings = {
 
 	'description': 'Helps guide you through the initial setup & claiming of your device',
 	'alreadyLoggedIn': 'It appears as though you are already logged in as %s',
-	'revokeAuthPrompt': 'Would you like to revoke the current authentication token?',
+	'revokeAuthPrompt': 'Would you like to use the current authentication token?',
 	'signupSuccess': "Great success! You're now the owner of a brand new account!",
 	'loginError': "There was an error logging you in! Let's try again.",
 	'helpForMoreInfo': 'Please try the `%s help` command for more information.'
@@ -96,16 +96,16 @@ SetupCommand.prototype.setup = function setup(shortcut) {
 
 			type: 'confirm',
 			name: 'switch',
-			message: 'Would you like to log in with a different account?',
-			default: false
+			message: 'Would you like to use this account?',
+			default: true
 
 		}], switchChoice);
 	}
 
 	function switchChoice(ans) {
 		// user wants to logout
-		if (ans.switch) {
-			cloud.logout().then(function() {
+		if (!ans.switch) {
+			cloud.logout(true).then(function() {
 				self.__api.clearToken();
 				self.__oldapi.clearToken();
 				accountStatus(false);

--- a/commands/SetupCommand/index.js
+++ b/commands/SetupCommand/index.js
@@ -316,6 +316,11 @@ SetupCommand.prototype.findDevice = function() {
 
 		console.log(arrow, 'No devices detected via USB.');
 
+		tryScan();
+	});
+
+	function tryScan() {
+		// TODO: check if Wi-Fi scanning is available (requires OS support and a wifi adapter.)
 		prompt([{
 
 			type: 'confirm',
@@ -372,8 +377,9 @@ SetupCommand.prototype.findDevice = function() {
 						return wireless.list(macAddress);
 					});
 					return;
+				} else {
+					tryScan();
 				}
-				console.log(arrow, 'Goodbye!');
 			});
 		} else if (device.type === 'Electron') {
 			detectedPrompt(device.type, function setupElectronChoice(ans) {

--- a/commands/SetupCommand/index.js
+++ b/commands/SetupCommand/index.js
@@ -554,7 +554,6 @@ SetupCommand.prototype.exit = function() {
 		chalk.bold.magenta('<3'))
 	);
 	process.exit(0);
-
 };
 
 module.exports = SetupCommand;

--- a/commands/WirelessCommand/WiFiManager.js
+++ b/commands/WirelessCommand/WiFiManager.js
@@ -26,6 +26,7 @@ function WiFiManager(opts) {
 WiFiManager.prototype.getCurrentNetwork = function(cb) {
 	if (!this.supported.getCurrentNetwork) {
 		// default to nothing
+		// todo - why not raise an error?
 		return cb();
 	}
 	this.osConnect.getCurrentNetwork(cb);

--- a/commands/WirelessCommand/connect/darwin.js
+++ b/commands/WirelessCommand/connect/darwin.js
@@ -110,7 +110,7 @@ function connect(opts, cb) {
 			cb(null, opts);
 		});
 	});
-};
+}
 
 module.exports = {
 	connect: connect,

--- a/commands/WirelessCommand/connect/linux.js
+++ b/commands/WirelessCommand/connect/linux.js
@@ -81,7 +81,7 @@ function connect(opts, cb) {
 	}
 
 	reconnect();
-};
+}
 
 module.exports = {
 	connect: connect,

--- a/commands/WirelessCommand/index.js
+++ b/commands/WirelessCommand/index.js
@@ -600,10 +600,13 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 		clearTimeout(retry);
 
 		if (retries >= 9) { // scan has failed 10 times already
+			self.stopSpin();
+
 			console.log(
 				arrow,
 				'Your Photon failed to scan for nearby Wi-Fi networks.'
 			);
+			retries = 0;
 			self.prompt([{
 				type: 'confirm',
 				name: 'manual',

--- a/commands/WirelessCommand/index.js
+++ b/commands/WirelessCommand/index.js
@@ -192,11 +192,8 @@ WirelessCommand.prototype.__networks = function networks(err, dat) {
 
 	detectedDevices = dat;
 	if (this.__macAddressFilter) {
-
 		var macDevices = detectedDevices.filter(function (ap) {
-
-			return ap.mac.toLowerCase() === self.__macAddressFilter;
-
+			return ap.mac && (ap.mac.toLowerCase() === self.__macAddressFilter);
 		});
 		if (macDevices && macDevices.length === 1) {
 

--- a/commands/WirelessCommand/index.js
+++ b/commands/WirelessCommand/index.js
@@ -105,6 +105,8 @@ WirelessCommand.prototype.init = function init() {
 	this.addOption('monitor', this.monitor.bind(this), 'Begin monitoring nearby Wi-Fi networks for Photons in setup mode.');
 };
 
+WirelessCommand.prototype.prompt = prompt;
+
 WirelessCommand.prototype.list = function list(macAddress, manual) {
 	if (manual) {
 		this.__manual = true;
@@ -137,8 +139,8 @@ WirelessCommand.prototype.list = function list(macAddress, manual) {
 	}
 };
 
-function manualAsk(cb) {
-	return prompt([{
+WirelessCommand.prototype.manualAsk = function manualAsk(cb) {
+	return this.prompt([{
 
 		type: 'confirm',
 		name: 'manual',
@@ -185,7 +187,7 @@ WirelessCommand.prototype.__networks = function networks(err, dat) {
 		console.log(alert, chalk.bold.white('OOPS:'), 'I was unable to scan for nearby Wi-Fi networks', chalk.magenta('(-___-)'));
 		console.log();
 
-		return manualAsk(manualChoice);
+		return this.manualAsk(manualChoice);
 	}
 
 	detectedDevices = dat;
@@ -208,7 +210,7 @@ WirelessCommand.prototype.__networks = function networks(err, dat) {
 	if (detectedDevices.length > 1) {
 
 		// Multiple Photons detected
-		prompt([{
+		this.prompt([{
 
 			type: 'confirm',
 			name: 'setup',
@@ -219,7 +221,7 @@ WirelessCommand.prototype.__networks = function networks(err, dat) {
 	} else if (detectedDevices.length === 1) {
 
 		// Perform wireless setup?
-		prompt([{
+		this.prompt([{
 
 			type: 'confirm',
 			name: 'setupSingle',
@@ -239,7 +241,7 @@ WirelessCommand.prototype.__networks = function networks(err, dat) {
 		);
 
 		// Monitor for new Photons?
-		prompt([{
+		this.prompt([{
 
 			type: 'confirm',
 			name: 'monitor',
@@ -277,7 +279,7 @@ WirelessCommand.prototype.__networks = function networks(err, dat) {
 			self.__batch = false;
 
 			// Select any/all Photons to setup
-			return prompt([{
+			return self.prompt([{
 
 				type: 'list',
 				name: 'selected',
@@ -303,9 +305,8 @@ WirelessCommand.prototype.__networks = function networks(err, dat) {
 		if (ans.setupSingle) {
 			self.setup(detectedDevices[0]);
 		} else {
-
 			// Monitor for new Photons?
-			prompt([{
+			self.prompt([{
 
 				type: 'confirm',
 				name: 'monitor',
@@ -386,7 +387,7 @@ WirelessCommand.prototype.setup = function setup(photon, cb) {
 					chalk.bold.white('You are still connected to your Photon\'s Wi-Fi network. Please reconnect to a Wi-Fi network with internet access.')
 				);
 				console.log();
-				prompt([{
+				self.prompt([{
 					type: 'confirm',
 					message: 'Have you reconnected to the internet?',
 					default: true,
@@ -438,7 +439,7 @@ WirelessCommand.prototype.setup = function setup(photon, cb) {
 			console.log(alert, 'I am unable to automatically connect to Wi-Fi networks', chalk.magenta('(-___-)'));
 			console.log();
 
-			return manualAsk(function (ans) {
+			return self.manualAsk(function (ans) {
 				if (ans.manual) {
 					self.__manual = true;
 					return manualConnect();
@@ -455,7 +456,7 @@ WirelessCommand.prototype.setup = function setup(photon, cb) {
 		}
 
 		function manualConnect() {
-			return prompt([{
+			return self.prompt([{
 
 				type: 'input',
 				name: 'connect',
@@ -515,7 +516,7 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 	protip(chalk.cyan('non-broadcast'), 'network, please choose No to the next prompt to enter manual mode.');
 	console.log();
 
-	prompt([{
+	self.prompt([{
 
 		type: 'confirm',
 		name: 'auto',
@@ -528,7 +529,7 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 
 		if (!ans.auto) {
 
-			return prompt([{
+			return self.prompt([{
 
 				type: 'input',
 				name: 'network',
@@ -603,8 +604,7 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 				arrow,
 				'Your Photon failed to scan for nearby Wi-Fi networks.'
 			);
-			prompt([{
-
+			self.prompt([{
 				type: 'confirm',
 				name: 'manual',
 				message: 'Would you like to manually enter your Wi-Fi network configuration?',
@@ -650,13 +650,11 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 		}
 		networks.unshift(new inquirer.Separator());
 
-		prompt([{
-
+		self.prompt([{
 			type: 'list',
 			name: 'network',
 			message: 'Please select the network to which your Photon should connect:',
 			choices: networks
-
 		}], __networkChoice);
 
 		function __networkChoice(ans) {
@@ -679,7 +677,7 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 				return networkChoices({ network: network });
 			}
 
-			prompt([{
+			self.prompt([{
 
 				type: 'input',
 				name: 'password',
@@ -688,7 +686,6 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 			}], __passwordChoice);
 		}
 		function __passwordChoice(ans) {
-
 			networkChoices({ network: network, password: ans.password });
 		}
 	}
@@ -717,7 +714,7 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 		console.log(arrow, 'Password:', chalk.bold.cyan(password || '[none]'));
 		console.log();
 
-		prompt([{
+		self.prompt([{
 			type: 'confirm',
 			name: 'continue',
 			message: 'Would you like to continue with the information shown above?',
@@ -826,7 +823,7 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 	}
 
 	function manualReconnectPrompt() {
-		prompt([{
+		self.prompt([{
 			name: 'reconnect',
 			type: 'input',
 			message: 'Please re-connect your computer to your Wi-Fi network now. Press enter when ready.'
@@ -895,7 +892,7 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 
 		console.log(alert, "It doesn't look like your Photon has made it to the cloud yet.");
 		console.log();
-		prompt([{
+		self.prompt([{
 
 			type: 'list',
 			name: 'recheck',
@@ -917,7 +914,7 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 	}
 
 	function namePhoton(deviceId) {
-		prompt([
+		self.prompt([
 			{
 				type: 'input',
 				name: 'deviceName',

--- a/commands/WirelessCommand/index.js
+++ b/commands/WirelessCommand/index.js
@@ -247,7 +247,7 @@ WirelessCommand.prototype.__networks = function networks(err, dat) {
 		console.log(alert, 'Try running', chalk.cyan(cmd + ' setup'), 'with Administrator privileges.');
 		console.log(alert, 'If the problem persists, please let us know:', chalk.cyan('https://community.particle.io/'));
 		console.log();
-	};
+	}
 
 	function multipleChoice(ans) {
 
@@ -266,7 +266,7 @@ WirelessCommand.prototype.__networks = function networks(err, dat) {
 			}], multipleAnswer);
 		}
 		self.exit();
-	};
+	}
 
 	function multipleAnswer(ans) {
 
@@ -275,7 +275,7 @@ WirelessCommand.prototype.__networks = function networks(err, dat) {
 			return self.setup(ans.selected);
 		}
 		self.exit();
-	};
+	}
 
 	function singleChoice(ans) {
 
@@ -293,7 +293,7 @@ WirelessCommand.prototype.__networks = function networks(err, dat) {
 
 			}], monitorChoice);
 		}
-	};
+	}
 
 	function monitorChoice(ans) {
 
@@ -304,7 +304,7 @@ WirelessCommand.prototype.__networks = function networks(err, dat) {
 		} else {
 			self.exit();
 		}
-	};
+	}
 
 	function manualDone(err, dat) {
 
@@ -315,8 +315,8 @@ WirelessCommand.prototype.__networks = function networks(err, dat) {
 		if (dat && dat.id) {
 
 			return console.log(arrow, 'We successfully configured your Photon! Great work. We make a good team!', chalk.magenta('<3'));
-		};
-	};
+		}
+	}
 };
 
 
@@ -452,14 +452,14 @@ WirelessCommand.prototype.setup = function setup(photon, cb) {
 
 			}], manualReady);
 		}
-	};
+	}
 
 	function manualReady() {
 		self.__configure(null, manualConfigure);
-	};
+	}
 	function manualConfigure(err, dat) {
 		cb(err, dat);
-	};
+	}
 
 	function connected(err, opts) {
 
@@ -478,7 +478,7 @@ WirelessCommand.prototype.setup = function setup(photon, cb) {
 			chalk.bold.cyan(opts.ssid)
 		);
 		self.__configure(opts.ssid);
-	};
+	}
 };
 
 WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
@@ -579,7 +579,7 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 			security: ans.security.toLowerCase().replace(' ', '_')
 
 		});
-	};
+	}
 
 	function start() {
 
@@ -602,7 +602,7 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 		}
 
 		sap.scan(results);
-	};
+	}
 
 	function results(err, dat) {
 		clearTimeout(retry);
@@ -676,7 +676,7 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 
 			networkChoices({ network: network, password: ans.password });
 		}
-	};
+	}
 
 	function networkChoices(ans) {
 
@@ -703,18 +703,16 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 		console.log();
 
 		prompt([{
-
 			type: 'confirm',
 			name: 'continue',
 			message: 'Would you like to continue with the information shown above?'
 
 		}], continueChoice);
-	};
+	}
 
 	function continueChoice(ans) {
 
 		if (!ans.continue) {
-
 			console.log(arrow, "Let's try again...");
 			console.log();
 			return self.__configure(ssid, cb);
@@ -723,7 +721,7 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 		self.__password = password;
 
 		info();
-	};
+	}
 
 	function info() {
 
@@ -747,7 +745,7 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 		clearTimeout(retry);
 		console.log(arrow, 'Requesting public key from the device...');
 		sap.publicKey(code);
-	};
+	}
 
 	function code(err) {
 		if (err) {
@@ -758,7 +756,7 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 		clearTimeout(retry);
 		console.log(arrow, 'Setting the magical cloud claim code...');
 		sap.setClaimCode(self.__claimCode, configure);
-	};
+	}
 
 	function configure(err) {
 		if (err) {
@@ -767,17 +765,15 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 		}
 
 		var conf = {
-
 			ssid: network,
 			security: security,
 			password: password
-
 		};
 
 		clearTimeout(retry);
 		console.log(arrow, 'Telling the Photon to apply your Wi-Fi configuration...');
 		sap.configure(conf, connect);
-	};
+	}
 
 	function connect(err) {
 		if (err) {
@@ -789,7 +785,7 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 		console.log();
 		clearTimeout(retry);
 		sap.connect(done);
-	};
+	}
 
 	function done(err) {
 		if (err) {
@@ -822,7 +818,7 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 		} else {
 			manualReconnectPrompt();
 		}
-	};
+	}
 
 	function manualReconnectPrompt() {
 		prompt([{
@@ -846,7 +842,8 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 		} else {
 			revived();
 		}
-	};
+	}
+
 	function revived(err) {
 		if (err) {
 			manualReconnectPrompt();
@@ -862,14 +859,14 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 
 		}, 2000);
 
-	};
+	}
 	function checkDevices(err, dat) {
 
 		self.stopSpin();
 		if (err) {
 
 			if (err.code === 'ENOTFOUND') {
-
+				// todo - limit the number of retries here.
 				console.log(alert, 'Network not ready yet, retrying...');
 				console.log();
 				return revived(null);
@@ -917,7 +914,8 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 				self.setup(self.__ssid);
 			}
 		}
-	};
+	}
+
 	function namePhoton(deviceId) {
 		prompt([
 			{
@@ -949,7 +947,6 @@ WirelessCommand.prototype.exit = function() {
 		chalk.bold.magenta('<3'))
 	);
 	process.exit(0);
-
 };
 
 function filter(list, pattern, inverse) {
@@ -962,14 +959,14 @@ function filter(list, pattern, inverse) {
 		// return false
 		return inverse ? !ap.ssid.match(pattern) : ap.ssid.match(pattern);
 	});
-};
+}
 
 function ssids(list) {
 
 	return clean(list).map(function map(ap) {
 		return ap.ssid;
 	});
-};
+}
 
 function removePhotonNetworks(ssids) {
 	return ssids.filter(function (ap) {
@@ -978,7 +975,7 @@ function removePhotonNetworks(ssids) {
 		}
 		return true;
 	});
-};
+}
 
 function clean(list) {
 

--- a/commands/WirelessCommand/index.js
+++ b/commands/WirelessCommand/index.js
@@ -42,7 +42,6 @@ var SAP = require('softap-setup');
 var path = require('path');
 
 var strings = {
-
 	'monitorPrompt': 'Would you like to wait and monitor for Photons entering setup mode?',
 	'scanError': 'Unable to scan for Wi-Fi networks. Do you have permission to do that on this computer?',
 	'credentialsNeeded': 'You will need to know the password for your Wi-Fi network (if any) to proceed.',
@@ -148,7 +147,7 @@ WirelessCommand.prototype.manualAsk = function manualAsk(cb) {
 		default: true
 
 	}], cb);
-}
+};
 
 function manualDone(err, dat) {
 	if (err) {
@@ -416,10 +415,8 @@ WirelessCommand.prototype.setup = function setup(photon, cb) {
 			// How about retrying the claim code again
 			// console.log(arrow, arrow, err);
 			if (err.code === 'ENOTFOUND') {
-
 				protip("Your computer couldn't find the cloud...");
 			} else {
-
 				protip('There was a network error while connecting to the cloud...');
 			}
 			protip('We need an active internet connection to successfully complete setup.');

--- a/commands/WirelessCommand/index.js
+++ b/commands/WirelessCommand/index.js
@@ -923,7 +923,7 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 			if (deviceName) {
 				self.__oldapi.renameDevice(deviceId, deviceName).then(function () {
 					console.log();
-					console.log(arrow, 'Your Photon has been bestowed with the name', chalk.bold.cyan(deviceName));
+					console.log(arrow, 'Your Photon has been given the name', chalk.bold.cyan(deviceName));
 					console.log(arrow, "Congratulations! You've just won the internet!");
 					console.log();
 					self.exit();

--- a/commands/WirelessCommand/index.js
+++ b/commands/WirelessCommand/index.js
@@ -505,15 +505,15 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 	prompt([{
 
 		type: 'confirm',
-		name: 'manual',
-		message: 'Would you like to manually enter your Wi-Fi network configuration?',
-		default: false
+		name: 'auto',
+		message: 'Shall I look for available Wi-Fi networks?',
+		default: true
 
 	}], scanChoice);
 
 	function scanChoice(ans) {
 
-		if (ans.manual) {
+		if (!ans.auto) {
 
 			return prompt([{
 
@@ -558,8 +558,7 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 
 		self.newSpin('Asking the Photon to scan for nearby Wi-Fi networks...').start();
 		retry = setTimeout(start, 1000);
-
-	};
+	}
 
 	function manualChoices(ans) {
 

--- a/commands/WirelessCommand/index.js
+++ b/commands/WirelessCommand/index.js
@@ -627,6 +627,7 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 		self.stopSpin();
 
 		if (err) {
+			console.error(err);
 			console.log(
 				arrow,
 				'Your Photon encountered an error while trying to scan for nearby Wi-Fi networks. Retrying...'
@@ -635,10 +636,9 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 			retries++;
 			return;
 		}
+		var networks = dat;
 
-		var networks = dat.scans;
-
-		dat.scans.forEach(function save(ap) {
+		dat.forEach(function save(ap) {
 			list[ap.ssid] = ap;
 		});
 
@@ -939,6 +939,7 @@ WirelessCommand.prototype.__configure = function __configure(ssid, cb) {
 				});
 			} else {
 				console.log('Skipping device naming.');
+				self.exit();
 			}
 		});
 	}

--- a/oldlib/SerialBoredParser.js
+++ b/oldlib/SerialBoredParser.js
@@ -1,7 +1,11 @@
 'use strict';
 
+/**
+ * A parser that waits for a given length of time for a response, or for a given terminator.
+ * @type {{makeParser: module.exports.makeParser}}
+ */
 module.exports = {
-	makeParser: function (boredDelay) {
+	makeParser: function (boredDelay, terminator) {
 		var boredTimer,
 			chunks = [];
 
@@ -17,10 +21,14 @@ module.exports = {
 			}, boredDelay);
 		};
 
-
 		return function (emitter, buffer) {
-			chunks.push(buffer.toString());
-			updateTimer(emitter);
+			var s = buffer.toString();
+			chunks.push(s);
+			if (terminator!==undefined && s.indexOf(terminator)>=0) {
+				whenBored(emitter);
+			} else {
+				updateTimer(emitter);
+			}
 		};
 	}
 };

--- a/oldlib/SerialBoredParser.js
+++ b/oldlib/SerialBoredParser.js
@@ -1,10 +1,29 @@
 'use strict';
 
+var original = {
+	setTimeout: global.setTimeout,
+	clearTimeout: global.clearTimeout
+};
+
+var setTimeoutLocal = function() {
+	original.setTimeout.apply(this, arguments);
+};
+
+var clearTimeoutLocal = function() {
+	original.clearTimeout.apply(this, arguments);
+};
+
+
 /**
  * A parser that waits for a given length of time for a response, or for a given terminator.
  * @type {{makeParser: module.exports.makeParser}}
  */
 module.exports = {
+	setTimeoutFunctions(setTimeout, clearTimeout) {
+		setTimeoutLocal = setTimeout;
+		clearTimeoutLocal = clearTimeout;
+	},
+
 	makeParser: function (boredDelay, terminator) {
 		var boredTimer,
 			chunks = [];
@@ -15,20 +34,24 @@ module.exports = {
 		};
 
 		var updateTimer = function (emitter) {
-			clearTimeout(boredTimer);
-			boredTimer = setTimeout(function () {
+			clearTimeoutLocal(boredTimer);
+			boredTimer = setTimeoutLocal(function () {
 				whenBored(emitter);
 			}, boredDelay);
 		};
 
-		return function (emitter, buffer) {
+		var result = function (emitter, buffer) {
 			var s = buffer.toString();
 			chunks.push(s);
+
 			if (terminator!==undefined && s.indexOf(terminator)>=0) {
 				whenBored(emitter);
+				clearTimeoutLocal(boredTimer);
+				boredTimer = undefined;
 			} else {
 				updateTimer(emitter);
 			}
 		};
+		return result;
 	}
 };

--- a/oldlib/SerialTrigger.js
+++ b/oldlib/SerialTrigger.js
@@ -17,33 +17,69 @@ SerialTrigger.prototype.addTrigger = function(prompt, next) {
 		throw new Error('prompt must be specified');
 	}
 	this.triggers[prompt] = next;
+	this.data = '';
 };
 
+/**
+ * There is no guarantee that 'data' events contain all of the data emitted by the device
+ * in one block, so we have to match on substrings.
+ * @param noLogs
+ */
 SerialTrigger.prototype.start = function(noLogs) {
-	var serialDataCallback = function (data) {
-		data = data.toString();
-		var self = this;
-		var triggerFn = _.find(this.triggers, function (fn, prompt) {
-			return data.indexOf(prompt) >= 0;
-		});
 
-		if (triggerFn) {
-			triggerFn(function (response, cb) {
-				if (response) {
-					self.port.flush(function () {
-						self.port.write(response, function () {
-							self.port.drain(function () {
-								if (!noLogs) {
-									log.serialInput(response);
-								}
-								if (cb) {
-									cb();
-								}
+	var serialDataCallback = function (data) {
+		var self = this;
+		this.data += data.toString();
+		var substring = this.data;
+		var substringMatch = '';
+		var matchPrompt = '';
+
+		while (!matchPrompt && substring) {
+			(function(substring) {
+				_.forOwn(self.triggers, function (fn, prompt) {
+					if (substring.length > prompt.length) {
+						if (substring.startsWith(prompt)) {
+							matchPrompt = prompt;
+							return false;   // quit iteration
+						}
+					} else {
+						if (prompt.startsWith(substring)) {
+							matchPrompt = prompt;
+							return false;
+						}
+					}
+				});
+			})(substring);
+
+			if (!matchPrompt) {
+				substring = substring.substring(1);
+			}
+		}
+
+		this.data = substring;
+
+		if (matchPrompt && substring.length >= matchPrompt.length) {
+			this.data = substring.substring(matchPrompt.length);
+
+			var triggerFn = this.triggers[matchPrompt];
+			if (triggerFn) {
+				triggerFn(function (response, cb) {
+					if (response) {
+						self.port.flush(function () {
+							self.port.write(response, function () {
+								self.port.drain(function () {
+									if (!noLogs) {
+										log.serialInput(response);
+									}
+									if (cb) {
+										cb();
+									}
+								});
 							});
 						});
-					});
-				}
-			});
+					}
+				});
+			}
 		}
 	};
 	this.dataCallback = serialDataCallback.bind(this);

--- a/oldlib/SerialTrigger.js
+++ b/oldlib/SerialTrigger.js
@@ -19,7 +19,7 @@ SerialTrigger.prototype.addTrigger = function(prompt, next) {
 	this.triggers[prompt] = next;
 };
 
-SerialTrigger.prototype.start = function() {
+SerialTrigger.prototype.start = function(noLogs) {
 	var serialDataCallback = function (data) {
 		data = data.toString();
 		var self = this;
@@ -31,9 +31,11 @@ SerialTrigger.prototype.start = function() {
 			triggerFn(function (response, cb) {
 				if (response) {
 					self.port.flush(function () {
-						self.port.write(response, function() {
+						self.port.write(response, function () {
 							self.port.drain(function () {
-								log.serialInput(response);
+								if (!noLogs) {
+									log.serialInput(response);
+								}
 								if (cb) {
 									cb();
 								}

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "request": "https://github.com/spark/request/releases/download/v2.75.1-relativepath.1/request-2.75.1-relativepath.1.tgz",
     "semver": "^5.1.0",
     "serialport": "^4.0.7",
-    "softap-setup": "^1.1.4",
+    "softap-setup": "^4.0.3",
     "temp": "^0.8.3",
     "when": "^3.7.2",
     "xtend": "^4.0.0",

--- a/test/mocks/Serial.mock.js
+++ b/test/mocks/Serial.mock.js
@@ -1,0 +1,45 @@
+var extend = require('extend');
+
+
+function MockSerial() {
+	var self = this;
+	self.open = false;
+	self.listeners = {};
+	return extend(this, {
+		drain: function (next) {
+			next();
+		},
+		flush: function (next) {
+			next();
+		},
+		on: function(type, cb) {
+			self.listeners[type] = cb;
+		},
+		respond: function (data) {
+			if (self.listeners.data) {
+				self.listeners.data(data);
+			}
+		},
+		open: function (cb) {
+			self.open = true;
+			cb();
+		},
+		removeAllListeners(type) {
+			this.removeListener(type);
+		},
+		removeListener(type) {
+			delete self.listeners[type];
+		},
+		isOpen: function() {
+			return self.open;
+		},
+		close: function(cb) {
+			self.open = false;
+			if (cb) {
+				cb();
+			}
+		}
+	});
+}
+
+module.exports = MockSerial;

--- a/test/oldcmd/SerialCommand.spec.js
+++ b/test/oldcmd/SerialCommand.spec.js
@@ -3,6 +3,16 @@
 var proxyquire = require('proxyquire');
 
 require('should');
+var sinon = require('sinon');
+var chai = require('chai');
+var sinonChai = require('sinon-chai');
+var chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+chai.use(sinonChai);
+var expect = chai.expect;
+var extend = require('extend');
+
+
 var Interpreter = require('../../oldlib/interpreter');
 
 var SerialCommand = proxyquire('../../commands/SerialCommand.js', {
@@ -11,39 +21,127 @@ var SerialCommand = proxyquire('../../commands/SerialCommand.js', {
 
 describe('Serial Command', function() {
 
-	var serial;
-
+	var cli, serial;
 	before(function() {
 
-		var cli = new Interpreter();
+		cli = new Interpreter();
 		cli.startup();
+	});
 
+	beforeEach(function () {
 		serial = new SerialCommand(cli, { });
-
 	});
 
 	it('Can list devices', function() {
-
 		serial.optionsByName['list'].should.be.an.instanceOf(Function);
 	});
 
 	it('Can monitor a device', function() {
-
 		serial.optionsByName['monitor'].should.be.an.instanceOf(Function);
 	});
 
 	it('Can identify a device', function() {
-
 		serial.optionsByName['identify'].should.be.an.instanceOf(Function);
 	});
 
 	it('Can setup Wi-Fi over serial', function() {
-
 		serial.optionsByName['wifi'].should.be.an.instanceOf(Function);
 	});
 
 	it('can retrieve mac address', function() {
-
 		serial.optionsByName['mac'].should.be.an.instanceOf(Function);
 	});
+
+
+	function MockSerial() {
+		var self = this;
+		self.open = false;
+		self.listeners = {};
+		return extend(this, {
+			drain: function (next) {
+				next();
+			},
+			flush: function (next) {
+				next();
+			},
+			on: function(type, cb) {
+				self.listeners[type] = cb;
+			},
+			respond: function (data) {
+				if (self.listeners.data) {
+					self.listeners.data(data);
+				}
+			},
+			open: function (cb) {
+				self.open = true;
+				cb();
+			},
+			removeAllListeners(type) {
+				this.removeListener(type);
+			},
+			removeListener(type) {
+				delete self.listeners[type];
+			},
+			isOpen: function() {
+				return self.open;
+			},
+			close: function(cb) {
+				self.open = false;
+				if (cb) {
+					cb();
+				}
+			}
+		});
+	}
+
+	describe('supportsClaimCode', function () {
+		it('can check if a device supports claiming', function () {
+			var device = { port: 'vintage' };
+			var mockSerial = new MockSerial();
+			mockSerial.write = function (data, cb) {
+				if (data==='c') {
+					mockSerial.respond('Device claimed: no');
+				}
+				cb();
+			};
+			serial.serialPort = mockSerial;
+			return expect(serial.supportsClaimCode(device)).to.eventually.equal(true);
+		});
+
+		it('supports a device that does not recognise the claim command', function () {
+			var device = { port: 'vintage' };
+			var mockSerial = new MockSerial();
+			mockSerial.write = function (data, cb) {
+				cb();
+			};
+			serial.serialPort = mockSerial;
+			return expect(serial.supportsClaimCode(device)).to.eventually.equal(false);
+		});
+	});
+
+	describe('sendClaimCode', function() {
+		it('can claim a device', function() {
+			var device = { port: 'shanghai' };
+			var mockSerial = new MockSerial();
+			var code = '1234';
+			mockSerial.write = function (data, cb) {
+				if (data==='C') {
+					mockSerial.expectingClaimCode = true;
+					mockSerial.respond('Enter 63-digit claim code: ');
+				}
+				else if (this.expectingClaimCode) {
+					mockSerial.expectingClaimCode = false;
+					mockSerial.claimCodeSet = data.split('\n')[0];
+					mockSerial.respond('Claim code set to: '+data);
+				}
+				cb();
+			};
+			serial.serialPort = mockSerial;
+			return serial.sendClaimCode(device, code, false).
+			then(function () {
+				expect(mockSerial.claimCodeSet).to.be.eql(code);
+			});
+		});
+	});
+
 });

--- a/test/oldcmd/SerialCommand.spec.js
+++ b/test/oldcmd/SerialCommand.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var proxyquire = require('proxyquire');
+var MockSerial = require('../mocks/Serial.mock')
 
 require('should');
 var sinon = require('sinon');
@@ -10,7 +11,6 @@ var chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 chai.use(sinonChai);
 var expect = chai.expect;
-var extend = require('extend');
 
 
 var Interpreter = require('../../oldlib/interpreter');
@@ -51,48 +51,6 @@ describe('Serial Command', function() {
 	it('can retrieve mac address', function() {
 		serial.optionsByName['mac'].should.be.an.instanceOf(Function);
 	});
-
-
-	function MockSerial() {
-		var self = this;
-		self.open = false;
-		self.listeners = {};
-		return extend(this, {
-			drain: function (next) {
-				next();
-			},
-			flush: function (next) {
-				next();
-			},
-			on: function(type, cb) {
-				self.listeners[type] = cb;
-			},
-			respond: function (data) {
-				if (self.listeners.data) {
-					self.listeners.data(data);
-				}
-			},
-			open: function (cb) {
-				self.open = true;
-				cb();
-			},
-			removeAllListeners(type) {
-				this.removeListener(type);
-			},
-			removeListener(type) {
-				delete self.listeners[type];
-			},
-			isOpen: function() {
-				return self.open;
-			},
-			close: function(cb) {
-				self.open = false;
-				if (cb) {
-					cb();
-				}
-			}
-		});
-	}
 
 	describe('supportsClaimCode', function () {
 		it('can check if a device supports claiming', function () {

--- a/test/oldlib/SerialBoredParser.spec.js
+++ b/test/oldlib/SerialBoredParser.spec.js
@@ -1,0 +1,80 @@
+
+var MockSerial = require('../mocks/Serial.mock');
+var proxyquire = require('proxyquire');
+var sinon = require('sinon');
+var chai = require('chai');
+var sinonChai = require('sinon-chai');
+var chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+chai.use(sinonChai);
+var expect = chai.expect;
+
+var serialBoredParser = require('../../oldlib/SerialBoredParser');
+
+describe('SerialBoredParser', function() {
+	var setTimeout, clearTimeout;
+
+	beforeEach(function () {
+		setTimeout = sinon.stub();
+		clearTimeout = sinon.stub();
+		serialBoredParser.setTimeoutFunctions(setTimeout, clearTimeout);
+	});
+
+	describe('terminator', function() {
+		it('returns before the timeout when the terminator is seen.', function() {
+			var terminator = 'arnie';
+			var timeout = 5000;
+			var sut = serialBoredParser.makeParser(timeout, terminator);
+			var timer = 'timer';
+			var emitter = { emit: sinon.stub() };
+
+			setTimeout.returns(timer);
+			sut(emitter, 'abc');
+			expect(clearTimeout).to.have.been.calledWith(undefined);
+
+			expect(setTimeout).has.been.calledWith(sinon.match.func, timeout);
+			expect(emitter.emit).to.have.not.been.called;
+
+			setTimeout.reset();
+			clearTimeout.reset();
+
+			sut(emitter, 'def'+terminator);
+			expect(emitter.emit).has.been.calledWith('data', 'abcdef'+terminator);
+			expect(setTimeout).to.have.not.been.called;
+			expect(clearTimeout).to.have.been.calledWith(timer);
+		});
+
+		it('waits for the timeout when the terminator is not seen.', function() {
+			var timeout = 50;
+			var sut = serialBoredParser.makeParser(timeout);
+			var terminator = 'arnie';
+			var timer = 'timer';
+			var emitter = { emit: sinon.stub() };
+
+			setTimeout.returns(timer);
+			sut(emitter, 'abc');
+			expect(clearTimeout).to.have.been.calledWith(undefined);
+			expect(setTimeout).has.been.calledWith(sinon.match.func, timeout);
+			expect(emitter.emit).to.have.not.been.called;
+
+			setTimeout.reset();
+			clearTimeout.reset();
+
+			sut(emitter, 'def');
+			expect(emitter.emit).to.have.not.been.called;
+			expect(clearTimeout).to.have.been.calledWith(timer);
+			expect(setTimeout).has.been.calledWith(sinon.match.func, timeout);
+
+			// now emulate the passage of time by calling the function passed to setTimeout
+			var timeoutFunction = setTimeout.args[0][0];
+			setTimeout.reset();
+			clearTimeout.reset();
+
+			timeoutFunction();
+			expect(emitter.emit).has.been.calledWith('data', 'abcdef');
+			expect(clearTimeout).to.have.not.been.called;
+			expect(setTimeout).has.not.been.called;
+		});
+
+	});
+});


### PR DESCRIPTION
various setup improvements:

- all prompts default to `Y`
- if the user chooses not to setup a locally connected USB device, continue scanning for wifi devices rather than exit. 
- does not show “Obtained magical secure claim code” when obtaining the claim code fails
- clarification on how to enter manual mode for non-broadcast networks
- adds a default prompt selection Yes when confirming Wi-Fi credentials
- removes the `Configuration complete: You have just won the internet prompt` since setup is not complete yet.
- removed prompt to switch back to the original network, and just do it automatically. 
- `--manual` flag to force manual wifi setup on OSes that don't have the wifi manager support.
- `--yes` flag to allow all questions to be answered yes by default.
- fix spinner bug after 9 retries of 
- use latest version of softap-setup which fixes issues relating to sockets not timing out (causing the CLI to hand indefinitely.)
