### PR TITLE
fixes compatibility with older node versions

### DIFF
--- a/commands/KeyCommands.js
+++ b/commands/KeyCommands.js
@@ -210,7 +210,7 @@ KeyCommands.prototype = extend(BaseCommand.prototype, {
 		return this._makeNewKey(filename);
 	},
 
-	keyAlgorithmForProtocol(protocol) {
+	keyAlgorithmForProtocol: function(protocol) {
 		return protocol === 'udp' ? 'ec' : 'rsa';
 	},
 

--- a/commands/SerialCommand.js
+++ b/commands/SerialCommand.js
@@ -555,6 +555,10 @@ SerialCommand.prototype = extend(BaseCommand.prototype, {
         var args = arguments;
 
 		this.whatSerialPortDidYouMean(comPort, true, function (device) {
+			function parameterMissing(param) {
+				return 'The "'+param+'" parameter was missing. Please specify a filename of a valid JSON object, ie {"network":"myNetwork","security":"WPA_AES","channel":2,"password":"mySecret!"}';
+			}
+
 			if (!device) {
 				return self.error('No serial port identified');
 			}
@@ -587,9 +591,7 @@ SerialCommand.prototype = extend(BaseCommand.prototype, {
                 // Directly
                 var obj = JSON.parse(fs.readFileSync(json, "utf-8"));
 
-	            function parameterMissing(param) {
-		            return 'The "'+param+'" parameter was missing. Please specify a filename of a valid JSON object, ie {"network":"myNetwork","security":"WPA_AES","channel":2,"password":"mySecret!"}';
-	            }
+
 
                 if (!obj.hasOwnProperty('network') || obj.network.length < 2){
                     _jsonErr(parameterMissing('network'));


### PR DESCRIPTION
submitted to fix compatibility with older node versions, specifically fixes the following:

```
Error loading command .../particle-cli/commands/KeyCommands.js SyntaxError: Unexpected token (
Error loading command .../particle-cli/commands/SerialCommand.js SyntaxError: In strict mode code, functions can only be declared at top level or immediately within another function.
```
