### PR TITLE
Feature/upload publish

### DIFF
--- a/accept/features/library_upload.feature
+++ b/accept/features/library_upload.feature
@@ -56,6 +56,16 @@ Feature: library upload
     And the output should contain "test-library-publish"
     And the output should not contain "[private]"
 
+  Scenario: can publish and upload a library in one step from the library directory
+    Given The particle library "test-library-publish" is removed
+    And I use the fixture named "library/upload/valid/0.0.2"
+    When I run particle "library publish"
+    # seems that the spinner output is not captured
+    # Then the output should contain "Uploading library test-library-publish"
+    Then the output should not contain "Library test-library-publish was successfully uploaded"
+    And the output should contain "Library test-library-publish was successfully published"
+    And the exit status should be 0
+
   Scenario: cleanup
     Given The particle library "test-library-publish" is removed
     When I run particle "library search test-library-publish"

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -236,7 +236,7 @@ export class CLI {
 			for (let error of nativeErrors) {
 				log.error(error);
 			}
-			log.fatal(`Please reinstall the CLI again using ${chalk.bold("npm install -g particle-cli")}`);
+			log.fatal(`Please reinstall the CLI again using ${chalk.bold('npm install -g particle-cli')}`);
 			return;
 		}
 


### PR DESCRIPTION
Allows `particle library publish` without a name argument when run from a directory containing a library. The library is first uploaded, then published. 

In future, we may add more stringent checks to the validation step during upload since we know the library will be immediately published. 