### PR TITLE
update particle-cli on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ The Particle CLI is a powerful tool for interacting with your IoT devices and th
 
 For the most up-to-date installation instructions, including Windows installer, see [CLI - Installation](https://docs.particle.io/guide/tools-and-features/cli/photon/#installing) on our documentation site.
 
+## Updating
 
+To make sure you are running the latest version of particle-cli, type the following command:
+
+```npm update -g particle-cli```
 
 ## Running from source (advanced)
 


### PR DESCRIPTION
In addition to installing and uninstalling, I'd thought it made sense to also show users how to **_update_** particle-cli.  There is a section on Particle Docs on how to do this, but I thought it might be convenient to see it on the Github repo which is where I was looking for it and couldn't find it.